### PR TITLE
fix: repoint hydra config targets and metrics paths from counterfactu…

### DIFF
--- a/cel/metrics/metrics.py
+++ b/cel/metrics/metrics.py
@@ -363,7 +363,7 @@ def evaluate_cf(
     median_log_prob: np.ndarray,
     y_target: np.ndarray = None,
     cf_group_ids: np.ndarray | None = None,
-    metrics_conf_path: str = "counterfactuals/pipelines/conf/metrics/default.yaml",
+    metrics_conf_path: str = "cel/pipelines/conf/metrics/default.yaml",
 ):
     y_target = torch.abs(1 - torch.from_numpy(y_test)) if y_target is None else y_target
     y_target = y_target.numpy() if isinstance(y_target, torch.Tensor) else y_target
@@ -402,7 +402,7 @@ def evaluate_cf_for_glance(
     y_target: np.ndarray,
     median_log_prob: np.ndarray,
     cf_group_ids: np.ndarray | None = None,
-    metrics_conf_path: str = "counterfactuals/pipelines/conf/metrics/group_metrics.yaml",
+    metrics_conf_path: str = "cel/pipelines/conf/metrics/group_metrics.yaml",
 ):
     metrics = evaluate_cf(
         disc_model=disc_model,

--- a/cel/metrics/orchestrator.py
+++ b/cel/metrics/orchestrator.py
@@ -47,7 +47,7 @@ class MetricsOrchestrator:
         ratio_cont: Optional[float] = None,
         prob_plausibility_threshold: Optional[float] = None,
         cf_group_ids: Optional[Union[np.ndarray, torch.Tensor]] = None,
-        metrics_conf_path: str = "counterfactuals/pipelines/conf/metrics/default.yaml",
+        metrics_conf_path: str = "cel/pipelines/conf/metrics/default.yaml",
     ) -> None:
         """Initialize the metrics orchestrator with data and models."""
         self.metrics_to_compute = OmegaConf.load(metrics_conf_path).metrics_to_compute

--- a/cel/pipelines/conf/ares_config.yaml
+++ b/cel/pipelines/conf/ares_config.yaml
@@ -13,7 +13,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/heloc.yaml
 
 disc_model:
@@ -33,7 +33,7 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.ares.AReS
+    _target_: cel.cf_methods.AReS
   
   # General parameters
   target_class: 0

--- a/cel/pipelines/conf/artelt_config.yaml
+++ b/cel/pipelines/conf/artelt_config.yaml
@@ -13,7 +13,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/blobs.yaml
 
 disc_model:
@@ -33,7 +33,7 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.artelt.Artelt
+    _target_: cel.cf_methods.Artelt
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/cadex_config.yaml
+++ b/cel/pipelines/conf/cadex_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/law.yaml
 
 disc_model:
@@ -32,7 +32,7 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.CADEX
+    _target_: cel.cf_methods.CADEX
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/cchvae_config.yaml
+++ b/cel/pipelines/conf/cchvae_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/lending_club.yaml
 
 disc_model:
@@ -33,11 +33,11 @@ gen_model:
 counterfactuals_params:
   cf_method:
     # specific parameters besides standard ones should be passed here
-    _target_: counterfactuals.cf_methods.CCHVAE
+    _target_: cel.cf_methods.CCHVAE
 
   disc_model_criterion:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
-    # _target_: counterfactuals.losses.BinaryDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
+    # _target_: cel.losses.BinaryDiscLoss
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/cchvae_traintest_config.yaml
+++ b/cel/pipelines/conf/cchvae_traintest_config.yaml
@@ -14,7 +14,7 @@ experiment:
   use_gpu: false
 
 dataset:
-  _target_: counterfactuals.datasets.TrainTestFileDataset
+  _target_: cel.datasets.TrainTestFileDataset
   config_path: config/datasets/heloc.yaml
   train_data_path: data/heloc_train.csv
   test_data_path: data/heloc_test.csv
@@ -36,10 +36,10 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.CCHVAE
+    _target_: cel.cf_methods.CCHVAE
 
   disc_model_criterion:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/cearm_config.yaml
+++ b/cel/pipelines/conf/cearm_config.yaml
@@ -13,7 +13,7 @@ experiment:
   num_folds: 5
 
 dataset:
-  _target_: counterfactuals.datasets.RegressionFileDataset
+  _target_: cel.datasets.regression_file_dataset.RegressionFileDataset
   config_path: config/datasets/toy_regression.yaml
 
 disc_model:
@@ -34,7 +34,7 @@ gen_model:
 counterfactuals_params:
   target_change: 0.2
   cf_method:
-    _target_: counterfactuals.cf_methods.regression_ppcef.CEARM
+    _target_: cel.cf_methods.CEARM
   epochs: 3000
   batch_size: 8096
   lr: 0.001
@@ -42,5 +42,5 @@ counterfactuals_params:
   patience: 300
   log_prob_quantile: 0.25
   disc_loss:
-    # _target_: counterfactuals.losses.MulticlassDiscLoss
-    _target_: counterfactuals.losses.ThresholdRegressionLoss
+    # _target_: cel.losses.MulticlassDiscLoss
+    _target_: cel.losses.ThresholdRegressionLoss

--- a/cel/pipelines/conf/cegp_config.yaml
+++ b/cel/pipelines/conf/cegp_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/blobs.yaml
 
 disc_model:
@@ -33,7 +33,7 @@ gen_model:
 counterfactuals_params:
   cf_method:
     # CEGP specific parameters
-    _target_: counterfactuals.cf_methods.CEGP
+    _target_: cel.cf_methods.CEGP
   beta: 0.01
   c_init: 1.0
   c_steps: 5

--- a/cel/pipelines/conf/cem_config.yaml
+++ b/cel/pipelines/conf/cem_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/blobs.yaml
 
 disc_model:
@@ -32,7 +32,7 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.CEM.CEM_CF
+    _target_: cel.cf_methods.CEM_CF
   # CEM specific parameters
   mode: "PN"  # 'PN' (pertinent negative) or 'PP' (pertinent positive)
   kappa: 0.2

--- a/cel/pipelines/conf/config_train_disc_model.yaml
+++ b/cel/pipelines/conf/config_train_disc_model.yaml
@@ -10,7 +10,7 @@ experiment:
   output_folder: models/
 
 dataset:
-  _target_: counterfactuals.datasets.DigitsDataset
+  _target_: cel.datasets.DigitsDataset
 
 disc_model:
   epochs: 500

--- a/cel/pipelines/conf/config_train_gen_model.yaml
+++ b/cel/pipelines/conf/config_train_gen_model.yaml
@@ -12,7 +12,7 @@ experiment:
   output_folder: models/
 
 dataset:
-  _target_: counterfactuals.datasets.WineDataset
+  _target_: cel.datasets.WineDataset
 
 gen_model:
   batch_size: 256

--- a/cel/pipelines/conf/dice_config.yaml
+++ b/cel/pipelines/conf/dice_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/lending_club.yaml
 
 disc_model:
@@ -32,11 +32,11 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.DiceExplainerWrapper
+    _target_: cel.cf_methods.group_methods.glance.dice_wrapper.DiceExplainerWrapper
 
   disc_model_criterion:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
-    # _target_: counterfactuals.losses.BinaryDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
+    # _target_: cel.losses.BinaryDiscLoss
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/dice_traintest_config.yaml
+++ b/cel/pipelines/conf/dice_traintest_config.yaml
@@ -14,7 +14,7 @@ experiment:
   use_gpu: false
 
 dataset:
-  _target_: counterfactuals.datasets.TrainTestFileDataset
+  _target_: cel.datasets.TrainTestFileDataset
   config_path: config/datasets/lending_club.yaml
   train_data_path: data/lending_club_train.csv
   test_data_path: data/lending_club_test.csv
@@ -36,10 +36,10 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.DiceExplainerWrapper
+    _target_: cel.cf_methods.group_methods.glance.dice_wrapper.DiceExplainerWrapper
 
   disc_model_criterion:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/disc_model/linear_regression.yaml
+++ b/cel/pipelines/conf/disc_model/linear_regression.yaml
@@ -1,2 +1,2 @@
 model:
-  _target_: counterfactuals.discriminative_models.LinearRegression
+  _target_: cel.models.LinearRegression

--- a/cel/pipelines/conf/disc_model/lr.yaml
+++ b/cel/pipelines/conf/disc_model/lr.yaml
@@ -1,2 +1,2 @@
 model:
-  _target_: counterfactuals.models.classifier.logistic_regression.LogisticRegression
+  _target_: cel.models.classifier.logistic_regression.LogisticRegression

--- a/cel/pipelines/conf/disc_model/mlp.yaml
+++ b/cel/pipelines/conf/disc_model/mlp.yaml
@@ -1,4 +1,4 @@
 model:
-  _target_: counterfactuals.models.classifier.multilayer_perceptron.MLPClassifier
+  _target_: cel.models.classifier.multilayer_perceptron.MLPClassifier
   hidden_layer_sizes: [256, 256]
   dropout: 0.2

--- a/cel/pipelines/conf/disc_model/mlp_large.yaml
+++ b/cel/pipelines/conf/disc_model/mlp_large.yaml
@@ -1,3 +1,3 @@
 model:
-  _target_: counterfactuals.discriminative_models.MultilayerPerceptron
+  _target_: cel.models.MultilayerPerceptron
   hidden_layer_sizes: [256, 256, 256]

--- a/cel/pipelines/conf/disc_model/mlr.yaml
+++ b/cel/pipelines/conf/disc_model/mlr.yaml
@@ -1,2 +1,2 @@
 model:
-  _target_: counterfactuals.models.classifier.logistic_regression.MultinomialLogisticRegression
+  _target_: cel.models.classifier.logistic_regression.MultinomialLogisticRegression

--- a/cel/pipelines/conf/disc_model/nn_regression.yaml
+++ b/cel/pipelines/conf/disc_model/nn_regression.yaml
@@ -1,3 +1,3 @@
 model:
-  _target_: counterfactuals.discriminative_models.NNRegression
+  _target_: cel.discriminative_models.NNRegression
   hidden_layer_sizes: [256, 128]

--- a/cel/pipelines/conf/disc_model/node.yaml
+++ b/cel/pipelines/conf/disc_model/node.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.discriminative_models.NODE
+  _target_: cel.models.NODE
   hidden_features: 128
   depth: 4
   num_layers: 1 

--- a/cel/pipelines/conf/flow_model/real_nvp.yaml
+++ b/cel/pipelines/conf/flow_model/real_nvp.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.models.generative.RealNVP
+  _target_: cel.models.generative.RealNVP
   hidden_features: 16
   num_blocks_per_layer: 4
   num_layers: 5

--- a/cel/pipelines/conf/gen_model/kde.yaml
+++ b/cel/pipelines/conf/gen_model/kde.yaml
@@ -1,3 +1,3 @@
 model:
-  _target_: counterfactuals.generative_models.KDE
+  _target_: cel.models.KDE
   bandwidth: 0.1

--- a/cel/pipelines/conf/gen_model/large_maf.yaml
+++ b/cel/pipelines/conf/gen_model/large_maf.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.models.generative.maf.maf.MaskedAutoregressiveFlow
+  _target_: cel.models.generative.maf.maf.MaskedAutoregressiveFlow
   hidden_features: 16
   num_blocks_per_layer: 4
   num_layers: 8

--- a/cel/pipelines/conf/gen_model/medium_maf.yaml
+++ b/cel/pipelines/conf/gen_model/medium_maf.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.generative_models.MaskedAutoregressiveFlow
+  _target_: cel.models.MaskedAutoregressiveFlow
   hidden_features: 4
   num_blocks_per_layer: 2
   num_layers: 5

--- a/cel/pipelines/conf/gen_model/nice.yaml
+++ b/cel/pipelines/conf/gen_model/nice.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.generative_models.NICE
+  _target_: cel.models.NICE
   hidden_features: 4
   num_blocks_per_layer: 2
   num_layers: 5

--- a/cel/pipelines/conf/gen_model/real_nvp.yaml
+++ b/cel/pipelines/conf/gen_model/real_nvp.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.models.generative.RealNVP
+  _target_: cel.models.generative.RealNVP
   hidden_features: 16
   num_blocks_per_layer: 4
   num_layers: 5

--- a/cel/pipelines/conf/gen_model/small_maf.yaml
+++ b/cel/pipelines/conf/gen_model/small_maf.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.generative_models.MaskedAutoregressiveFlow
+  _target_: cel.models.MaskedAutoregressiveFlow
   hidden_features: 4
   num_blocks_per_layer: 2
   num_layers: 1

--- a/cel/pipelines/conf/glance_config.yaml
+++ b/cel/pipelines/conf/glance_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/heloc.yaml
 
 disc_model:
@@ -33,14 +33,14 @@ gen_model:
 counterfactuals_params:
   cf_method:
     # specific parameters besides standard ones should be passed here
-    _target_: counterfactuals.cf_methods.glance.GlobalGLANCE
+    _target_: cel.cf_methods.glance.GlobalGLANCE
     k: 50
     m: 10
     s: 1
 
   disc_model_criterion:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
-    # _target_: counterfactuals.losses.BinaryDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
+    # _target_: cel.losses.BinaryDiscLoss
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/globe_ce_config.yaml
+++ b/cel/pipelines/conf/globe_ce_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/heloc.yaml
 
 disc_model:
@@ -32,7 +32,7 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.globe_ce.GLOBE_CE
+    _target_: cel.cf_methods.GLOBE_CE
   
   # General parameters
   target_class: 1

--- a/cel/pipelines/conf/group_globe_ce_config.yaml
+++ b/cel/pipelines/conf/group_globe_ce_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.WineDataset
+  _target_: cel.datasets.WineDataset
 
 disc_model:
   train_model: true
@@ -31,7 +31,7 @@ gen_model:
 
 counterfactuals_params:
   cf_method:
-    _target_: counterfactuals.cf_methods.globe_ce.Group_GLOBE_CE
+    _target_: cel.cf_methods.globe_ce.Group_GLOBE_CE
   
   # General parameters
   target_class: 0

--- a/cel/pipelines/conf/other_methods/config_artelt.yaml
+++ b/cel/pipelines/conf/other_methods/config_artelt.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: false
 
 dataset:
-  _target_: counterfactuals.datasets.MoonsDataset
+  _target_: cel.datasets.MoonsDataset
 
 reference_method: "artelth20"
 pca_dim: 25

--- a/cel/pipelines/conf/other_methods/config_cbce.yaml
+++ b/cel/pipelines/conf/other_methods/config_cbce.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: false
 
 dataset:
-  _target_: counterfactuals.datasets.WineDataset
+  _target_: cel.datasets.WineDataset
 
 reference_method: "cbce"
 pca_dim: 25

--- a/cel/pipelines/conf/other_methods/config_cegp.yaml
+++ b/cel/pipelines/conf/other_methods/config_cegp.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: false
 
 dataset:
-  _target_: counterfactuals.datasets.AuditDataset
+  _target_: cel.datasets.AuditDataset
 
 reference_method: "CEGP"
 pca_dim: 25

--- a/cel/pipelines/conf/other_methods/config_cem.yaml
+++ b/cel/pipelines/conf/other_methods/config_cem.yaml
@@ -13,7 +13,7 @@ experiment:
   relabel_with_disc_model: false
 
 dataset:
-  _target_: counterfactuals.datasets.WineDataset
+  _target_: cel.datasets.WineDataset
 
 reference_method: "CEM"
 pca_dim: 25

--- a/cel/pipelines/conf/other_methods/config_wach.yaml
+++ b/cel/pipelines/conf/other_methods/config_wach.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: false
 
 dataset:
-  _target_: counterfactuals.datasets.MoonsDataset
+  _target_: cel.datasets.MoonsDataset
 
 reference_method: "wach"
 pca_dim: 25
@@ -25,7 +25,7 @@ counterfactuals:
   beta: 0.01
   patience: 500
   disc_loss:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
 
 # gen_model:
 #   batch_size: 256

--- a/cel/pipelines/conf/other_methods/disc_model/lr.yaml
+++ b/cel/pipelines/conf/other_methods/disc_model/lr.yaml
@@ -1,2 +1,2 @@
 model:
-  _target_: counterfactuals.discriminative_models.LogisticRegression
+  _target_: cel.models.LogisticRegression

--- a/cel/pipelines/conf/other_methods/disc_model/mlp.yaml
+++ b/cel/pipelines/conf/other_methods/disc_model/mlp.yaml
@@ -1,3 +1,3 @@
 model:
-  _target_: counterfactuals.discriminative_models.MultilayerPerceptron
+  _target_: cel.models.MultilayerPerceptron
   hidden_layer_sizes: [256, 256, 256]

--- a/cel/pipelines/conf/other_methods/disc_model/mlr.yaml
+++ b/cel/pipelines/conf/other_methods/disc_model/mlr.yaml
@@ -1,2 +1,2 @@
 model:
-  _target_: counterfactuals.discriminative_models.MultinomialLogisticRegression
+  _target_: cel.models.MultinomialLogisticRegression

--- a/cel/pipelines/conf/other_methods/disc_model/node.yaml
+++ b/cel/pipelines/conf/other_methods/disc_model/node.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.discriminative_models.NODE
+  _target_: cel.models.NODE
   hidden_features: 128
   depth: 4
   num_layers: 1 

--- a/cel/pipelines/conf/other_methods/gen_model/kde.yaml
+++ b/cel/pipelines/conf/other_methods/gen_model/kde.yaml
@@ -1,3 +1,3 @@
 model:
-  _target_: counterfactuals.generative_models.KDE
+  _target_: cel.models.KDE
   bandwidth: 0.1

--- a/cel/pipelines/conf/other_methods/gen_model/large_maf.yaml
+++ b/cel/pipelines/conf/other_methods/gen_model/large_maf.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.generative_models.MaskedAutoregressiveFlow
+  _target_: cel.models.MaskedAutoregressiveFlow
   hidden_features: 16
   num_blocks_per_layer: 4
   num_layers: 8

--- a/cel/pipelines/conf/other_methods/gen_model/medium_maf.yaml
+++ b/cel/pipelines/conf/other_methods/gen_model/medium_maf.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.generative_models.MaskedAutoregressiveFlow
+  _target_: cel.models.MaskedAutoregressiveFlow
   hidden_features: 4
   num_blocks_per_layer: 2
   num_layers: 5

--- a/cel/pipelines/conf/other_methods/gen_model/small_maf.yaml
+++ b/cel/pipelines/conf/other_methods/gen_model/small_maf.yaml
@@ -1,5 +1,5 @@
 model:
-  _target_: counterfactuals.generative_models.MaskedAutoregressiveFlow
+  _target_: cel.models.MaskedAutoregressiveFlow
   hidden_features: 4
   num_blocks_per_layer: 2
   num_layers: 1

--- a/cel/pipelines/conf/ppcef_config.yaml
+++ b/cel/pipelines/conf/ppcef_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/law.yaml
 
 disc_model:
@@ -33,11 +33,11 @@ gen_model:
 counterfactuals_params:
   cf_method:
     # specific parameters besides standard ones should be passed here
-    _target_: counterfactuals.cf_methods.PPCEF
+    _target_: cel.cf_methods.PPCEF
 
   disc_model_criterion:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
-    # _target_: counterfactuals.losses.BinaryDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
+    # _target_: cel.losses.BinaryDiscLoss
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/conf/tcrex_config.yaml
+++ b/cel/pipelines/conf/tcrex_config.yaml
@@ -18,7 +18,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/moons.yaml
 
 disc_model:
@@ -40,7 +40,7 @@ gen_model:
 counterfactuals_params:
   cf_method:
     # specific parameters besides standard ones should be passed here
-    _target_: counterfactuals.cf_methods.TCREx
+    _target_: cel.cf_methods.TCREx
   # TCREx specific parameters
   tau: 0.9  # Accuracy threshold for valid rules
   rho: 0.02  # Feasibility threshold for valid rules

--- a/cel/pipelines/conf/wach_config.yaml
+++ b/cel/pipelines/conf/wach_config.yaml
@@ -12,7 +12,7 @@ experiment:
   relabel_with_disc_model: true
 
 dataset:
-  _target_: counterfactuals.datasets.FileDataset
+  _target_: cel.datasets.FileDataset
   config_path: config/datasets/blobs.yaml
 
 disc_model:
@@ -33,13 +33,13 @@ gen_model:
 counterfactuals_params:
   cf_method:
     # specific parameters besides standard ones should be passed here
-    _target_: counterfactuals.cf_methods.RPPCEF
+    _target_: cel.cf_methods.RPPCEF
     cf_method_type: "PPCEF_2"
     K: 1
 
   disc_model_criterion:
-    _target_: counterfactuals.losses.MulticlassDiscLoss
-    # _target_: counterfactuals.losses.BinaryDiscLoss
+    _target_: cel.losses.MulticlassDiscLoss
+    # _target_: cel.losses.BinaryDiscLoss
 
   log_prob_quantile: 0.25
   target_class: 0

--- a/cel/pipelines/run_dice_pairwise_pipeline.py
+++ b/cel/pipelines/run_dice_pairwise_pipeline.py
@@ -219,8 +219,7 @@ def calculate_metrics(
         y_test=y_test,
         median_log_prob=median_log_prob,
         y_target=y_target,
-        metrics_conf_path=metrics_conf_path
-        or "counterfactuals/pipelines/conf/metrics/default.yaml",
+        metrics_conf_path=metrics_conf_path or "cel/pipelines/conf/metrics/default.yaml",
     )
 
     # Calculate pairwise distance on all CFs

--- a/cel/pipelines/run_dice_traintest_pipeline.py
+++ b/cel/pipelines/run_dice_traintest_pipeline.py
@@ -5,7 +5,7 @@ where train and test splits are provided as separate files, rather than using
 cross-validation.
 
 Usage:
-    uv run python -m counterfactuals.pipelines.run_dice_traintest_pipeline \
+    uv run python -m cel.pipelines.run_dice_traintest_pipeline \
         dataset.train_data_path=data/my_train.csv \
         dataset.test_data_path=data/my_test.csv
 """
@@ -252,8 +252,7 @@ def calculate_metrics(
         y_test=y_test,
         median_log_prob=median_log_prob,
         y_target=y_target,
-        metrics_conf_path=metrics_conf_path
-        or "counterfactuals/pipelines/conf/metrics/default.yaml",
+        metrics_conf_path=metrics_conf_path or "cel/pipelines/conf/metrics/default.yaml",
     )
 
     # Calculate pairwise distance on all CFs

--- a/cel/pipelines/run_glance_pipeline.py
+++ b/cel/pipelines/run_glance_pipeline.py
@@ -136,7 +136,7 @@ def calculate_metrics(
         y_target=y_target,
         median_log_prob=median_log_prob,
         cf_group_ids=cf_group_ids,
-        metrics_conf_path="counterfactuals/pipelines/conf/metrics/default.yaml",
+        metrics_conf_path="cel/pipelines/conf/metrics/default.yaml",
     )
     logger.info("Metrics calculated: %s", metrics)
     return metrics


### PR DESCRIPTION
The library was renamed from 'counterfactuals' to 'cel', but the Hydra pipeline configs and a few hardcoded metrics-config paths still referenced the old package, so every pipeline failed at instantiation. Update all _target_ paths and metrics_conf_path strings to the cel package, and correct stale submodule paths (discriminative_models/generative_models -> models, method/dataset targets to their exported locations).