### PR TITLE
fix(cchvae): enforce valid one-hot categoricals in reconstruction

### DIFF
--- a/cel/cf_methods/local_methods/c_chvae/c_chvae.py
+++ b/cel/cf_methods/local_methods/c_chvae/c_chvae.py
@@ -163,7 +163,7 @@ class CCHVAE(BaseCounterfactualMethod, LocalCounterfactualMixin):
         return candidate_counterfactuals, dist
 
     def _counterfactual_search(
-        self, step: int, factual: torch.Tensor, cat_features_indices: list
+        self, step: int, factual: torch.Tensor, cat_feature_groups: list[list[int]]
     ) -> pd.DataFrame:
         """Searches for a counterfactual by expanding a hypersphere in latent space.
 
@@ -175,7 +175,7 @@ class CCHVAE(BaseCounterfactualMethod, LocalCounterfactualMixin):
         Args:
           step: Increment used to expand the search radius after unsuccessful attempts.
           factual: Single factual instance as a tensor of shape `(1, d)`.
-          cat_features_indices: Column indices for encoded categorical features.
+          cat_feature_groups: One-hot column-index groups, one per categorical feature.
 
         Returns:
           A single counterfactual instance as a 1D NumPy array of shape `(d,)`.
@@ -230,9 +230,7 @@ class CCHVAE(BaseCounterfactualMethod, LocalCounterfactualMixin):
             temp[:, self._generative_model.mutable_mask] = x_ce.to(temp.dtype)
             x_ce = temp
 
-            x_ce = reconstruct_encoding_constraints(
-                x_ce, cat_features_indices, self._params["binary_cat_features"]
-            )
+            x_ce = reconstruct_encoding_constraints(x_ce, cat_feature_groups)
             x_ce = x_ce.detach().cpu().numpy()
             x_ce = x_ce.clip(0, 1) if self._clamp else x_ce
 
@@ -276,14 +274,11 @@ class CCHVAE(BaseCounterfactualMethod, LocalCounterfactualMixin):
         """
         factuals = self._mlmodel.get_ordered_features(factuals)
 
-        encoded_feature_names = self._mlmodel.data.categorical
-        cat_features_indices = [
-            factuals.columns.get_loc(feature) for feature in encoded_feature_names
-        ]
+        cat_feature_groups = self._mlmodel.data._dataset.categorical_features_lists
 
         df_cfs = factuals.apply(
             lambda x: self._counterfactual_search(
-                self._step, x.reshape((1, -1)), cat_features_indices
+                self._step, x.reshape((1, -1)), cat_feature_groups
             ),
             raw=True,
             axis=1,
@@ -307,14 +302,11 @@ class CCHVAE(BaseCounterfactualMethod, LocalCounterfactualMixin):
         """
         factuals = self._mlmodel.get_ordered_features(factuals)
 
-        encoded_feature_names = self._mlmodel.data.categorical
-        cat_features_indices = [
-            factuals.columns.get_loc(feature) for feature in encoded_feature_names
-        ]
+        cat_feature_groups = self._mlmodel.data._dataset.categorical_features_lists
 
         df_cfs = factuals.apply(
             lambda x: self._counterfactual_search(
-                self._step, x.reshape((1, -1)), cat_features_indices
+                self._step, x.reshape((1, -1)), cat_feature_groups
             ),
             raw=True,
             axis=1,

--- a/cel/cf_methods/local_methods/c_chvae/utils.py
+++ b/cel/cf_methods/local_methods/c_chvae/utils.py
@@ -100,44 +100,43 @@ def merge_default_parameters(hyperparams: dict | None, default: dict) -> dict:
 
 
 def reconstruct_encoding_constraints(
-    x: torch.Tensor, feature_pos: list[int], binary_cat: bool
+    x: torch.Tensor, feature_groups: list[list[int]]
 ) -> torch.Tensor:
     """
-    Reconstructing one-hot-encoded data, such that its values are either 0 or 1,
-    and features do not contradict (e.g., sex_female = 1, sex_male = 1)
+    Project one-hot-encoded categorical blocks back onto valid vertices, so that
+    each categorical group has exactly one active column (sum == 1) and no
+    contradictions (e.g., sex_female = 1 and sex_male = 1 at the same time).
+
+    The decoder produces soft values per column; rounding each column
+    independently can yield multiple active columns or an all-zero group. Taking
+    the argmax within each group guarantees a valid one-hot vector.
 
     Parameters
     ----------
     x:
-        Instance where we want to reconstruct categorical constraints.
-    feature_pos:
-        list with positions of categorical features in x.
-    binary_cat:
-        If True, categorical datas are encoded with drop_if_binary.
+        Instance(s) whose categorical blocks should be made one-hot-valid.
+    feature_groups:
+        List of column-index groups, one per original categorical feature (as
+        produced by ``categorical_features_lists``). A single-column group is
+        treated as a binary indicator and simply rounded.
 
     Returns
     -------
-    Tensor with reconstructed constraints
+    Tensor with each categorical group snapped to a valid one-hot vector.
     """
     x_enc = x.clone()
 
-    if binary_cat:
-        for pos in feature_pos:
-            x_enc[:, pos] = torch.round(x_enc[:, pos])
-    else:
-        binary_pairs = list(zip(feature_pos[:-1], feature_pos[1:]))[0::2]
-        for pair in binary_pairs:
-            # avoid overwritten inconsistent results
-            temp = (x_enc[:, pair[0]] >= x_enc[:, pair[1]]).float()
+    for group in feature_groups:
+        if not group:
+            continue
+        if len(group) == 1:
+            x_enc[:, group[0]] = torch.round(x_enc[:, group[0]])
+            continue
 
-            x_enc[:, pair[1]] = (x_enc[:, pair[0]] < x_enc[:, pair[1]]).float()
-            x_enc[:, pair[0]] = temp
-
-            if (x_enc[:, pair[0]] == x_enc[:, pair[1]]).any():
-                raise ValueError(
-                    "Reconstructing encoded features lead to an error. Feature {} and {} have the same value".format(
-                        pair[0], pair[1]
-                    )
-                )
+        idx = torch.as_tensor(group, device=x_enc.device, dtype=torch.long)
+        winner = torch.argmax(x_enc[:, idx], dim=1)
+        one_hot = torch.zeros((x_enc.shape[0], len(group)), dtype=x_enc.dtype, device=x_enc.device)
+        one_hot[torch.arange(x_enc.shape[0]), winner] = 1.0
+        x_enc[:, idx] = one_hot
 
     return x_enc


### PR DESCRIPTION
## Problem

CCHVAE's `reconstruct_encoding_constraints` projected decoder outputs back to categorical constraints by **rounding each encoded column independently** (`binary_cat=True`) or **pairing consecutive columns** (`binary_cat=False`). Both branches assume binary categoricals.

For full one-hot features with more than two categories (e.g. **Adult Income**, encoded with `drop_first: false`), independent rounding yields rows with **multiple active columns** or an **all-zero group** — structurally invalid one-hot. Measured on Adult (5-fold CV output), only **~46%** of returned counterfactuals were valid one-hot.

This is CCHVAE-specific: PPCEF/CADEX post-process with a group-argmax projection (`apply_categorical_discretization`), while CCHVAE relied on the per-column round.

## Fix

Rewrite `reconstruct_encoding_constraints` to take the real one-hot column **groups** (`categorical_features_lists`) and apply a **per-group argmax → one-hot**, guaranteeing exactly one active column per categorical group. Single-column groups are still rounded, preserving drop-first binary encodings. `_counterfactual_search` now passes the group structure instead of a flat index list.

## Verification

On Adult (191 one-hot columns, 8 groups), feeding random/tie/all-zero decoder outputs through the new projection:

- every categorical group sums to exactly **1** across all rows
- categorical columns are strictly {0, 1}
- continuous features left untouched

**One-hot validity: ~46% → 100%.**

## Notes

- The `binary_cat_features` hyperparameter is no longer used by the reconstruction; it remains accepted in config (harmless) and can be removed in a follow-up.
- End-to-end pipeline validation on Adult is currently blocked on an unrelated local change swapping the pipeline scaler to `StandardScalingStep` (CCHVAE's VAE uses BCE and requires inputs in `[0, 1]`); with the standard `MinMaxScalingStep` the pipeline runs normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)