### PR TITLE
feat(dicoflex): repro-parity flow space and neighbor hyperparameters

### DIFF
--- a/counterfactuals/pipelines/conf/dictum_dicoflex_config.yaml
+++ b/counterfactuals/pipelines/conf/dictum_dicoflex_config.yaml
@@ -18,12 +18,13 @@ experiment:
   relabel_with_disc_model: true
   seed: 42
   use_gpu: false
-  # Original DiCoFlex generation space (ofurman/DiCoFlex): MinMax on numeric
-  # features + QuantileTransformer on the one-hot categoricals. StandardScaler is
-  # used ONLY for metric computation (compute_dictum_metrics --scaler standard
-  # --generation-scaler minmax_qt), so explanations are found in the original
-  # space and reported in DICTUM's z-scored space.
-  model_space_scaler: minmax_qt
+  # Flow generation space: MinMax on numeric features, one-hot categoricals kept
+  # as raw 0/1 — matching the brinpow/dicoflex_repro reproduction (its
+  # feature_transformer is MinMax + plain OneHotEncoder, no QuantileTransformer).
+  # StandardScaler is used ONLY for metric computation (compute_dictum_metrics
+  # --scaler standard --generation-scaler minmax), so explanations are found in
+  # the generation space and reported in DICTUM's z-scored space.
+  model_space_scaler: minmax
   # The shared DICTUM classifier (scripts/train_shared_disc_model.py, run with
   # dictum_dice_config) is trained in `standard` space. Naming its space here
   # makes the pipeline wrap it in SpaceAdapterClassifier, so every prediction
@@ -69,8 +70,10 @@ counterfactuals_params:
   n_test_samples: 2000
   p_values: [2.0]
   inference_p_value: 2.0
-  n_neighbors: 16
-  noise_level: 0.02
+  # 32 neighbors and 0.01 noise match the brinpow/dicoflex_repro tabular runs
+  # (train_generic_counterfactual.py: n_nearest=32, noise_level=0.01).
+  n_neighbors: 32
+  noise_level: 0.01
   train_batch_factuals: 4
   val_ratio: 0.2
   num_counterfactuals: 100


### PR DESCRIPTION
## Summary
Stacked on #68. One hyperparameter change set, isolated for tracking:
- `model_space_scaler: minmax_qt` → `minmax` — flow generates in MinMax + raw 0/1 one-hots, exactly the `brinpow/dicoflex_repro` feature space (no QuantileTransformer)
- `n_neighbors: 16` → `32` (repro `n_nearest=32`)
- `noise_level: 0.02` → `0.01` (repro `noise_level=0.01`)

Classifier stays shared + standard-space behind `SpaceAdapterClassifier`. Remaining known repro differences NOT in this PR: `prob_threshold=0.55` neighbor filter, p_values `[1e-2, 2.0]`, NaN-candidate resampling policy.

## Test plan
- Retrain 5 datasets on Helios GPU (seed 42), generate on experiment machine
- Score with `--generation-scaler minmax --scaler standard --metric-encoding ordinal --disc-scaler standard`, compare against the minmax_qt table in #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)