### PR TITLE
feat(dicoflex): DiCoFlex counterfactual method on develop

### DIFF
--- a/cel/cf_methods/local_methods/__init__.py
+++ b/cel/cf_methods/local_methods/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
 from .cegp.cegp import CEGP
 from .cem.cem import CEM_CF
 from .dice.dice import DICE
+from .dicoflex import DiCoFlex, DiCoFlexParams
 from .ppcef.ppcef import PPCEF
 from .sace.sace import SACE
 from .wach.wach import WACH
@@ -23,6 +24,8 @@ __all__ = [
     "CEGP",
     "CEM_CF",
     "DICE",
+    "DiCoFlex",
+    "DiCoFlexParams",
     "PPCEF",
     "SACE",
     "WACH",

--- a/cel/cf_methods/local_methods/dicoflex/__init__.py
+++ b/cel/cf_methods/local_methods/dicoflex/__init__.py
@@ -1,0 +1,5 @@
+"""Expose the DiCoFlex counterfactual generator."""
+
+from .method import DiCoFlex, DiCoFlexParams
+
+__all__ = ["DiCoFlex", "DiCoFlexParams"]

--- a/cel/cf_methods/local_methods/dicoflex/context_utils.py
+++ b/cel/cf_methods/local_methods/dicoflex/context_utils.py
@@ -1,0 +1,107 @@
+"""Context helpers for the DiCoFlex conditional flow."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+import numpy as np
+import torch
+
+
+def _ensure_float32_contiguous(array: np.ndarray) -> np.ndarray:
+    """Return a float32 contiguous view of the provided array."""
+    return np.ascontiguousarray(array.astype(np.float32, copy=False))
+
+
+def _label_to_index(label: float | int, class_to_index: Dict[int, int]) -> int:
+    """Map a raw label value to its contiguous class index."""
+    if label in class_to_index:
+        return class_to_index[label]
+    as_int = int(label)
+    if as_int in class_to_index:
+        return class_to_index[as_int]
+    raise KeyError(f"Label {label!r} not found in class mapping {class_to_index}")
+
+
+def build_context_matrix(
+    factual_points: np.ndarray,
+    labels: np.ndarray,
+    mask_vector: np.ndarray,
+    p_value: float,
+    class_to_index: Dict[int, int],
+) -> torch.Tensor:
+    """Construct the DiCoFlex conditioning matrix for a batch of samples."""
+    factual = _ensure_float32_contiguous(factual_points)
+    n_samples, n_features = factual.shape
+    mask = _ensure_float32_contiguous(mask_vector).reshape(1, -1)
+    if mask.shape[1] != n_features:
+        raise ValueError(
+            "Mask dimensionality does not match number of features "
+            f"({mask.shape[1]} != {n_features})."
+        )
+
+    mask_block = np.repeat(mask, repeats=n_samples, axis=0)
+    label_indices = np.array(
+        [_label_to_index(label, class_to_index) for label in labels.reshape(-1)],
+        dtype=np.int64,
+    )
+    num_classes = len(class_to_index)
+    class_one_hot = np.zeros((n_samples, num_classes), dtype=np.float32)
+    class_one_hot[np.arange(n_samples), label_indices] = 1.0
+    p_column = np.full((n_samples, 1), float(p_value), dtype=np.float32)
+
+    context_np = np.concatenate(
+        [factual, class_one_hot, mask_block, p_column],
+        axis=1,
+    )
+    return torch.from_numpy(context_np)
+
+
+def get_numpy_pointer(array: np.ndarray) -> int:
+    """Return the base memory pointer for a numpy array."""
+    return int(array.__array_interface__["data"][0])
+
+
+class DiCoFlexGeneratorMetricsAdapter(torch.nn.Module):
+    """
+    Adapter that supplies the correct conditioning vectors when the generative
+    model is queried by the metrics framework.
+    """
+
+    def __init__(
+        self,
+        base_model: torch.nn.Module,
+        context_lookup: Dict[int, torch.Tensor],
+    ) -> None:
+        super().__init__()
+        self.base_model = base_model
+        self.context_lookup = context_lookup
+
+    def eval(self) -> "DiCoFlexGeneratorMetricsAdapter":
+        """Set the underlying model to eval mode and return self."""
+        self.base_model.eval()
+        return self
+
+    def forward(self, X: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        """Proxy forward pass that injects the stored context."""
+        context = self._resolve_context(X)
+        if context.device != X.device:
+            context = context.to(X.device)
+        return self.base_model(X, context=context)
+
+    def _resolve_context(self, X: torch.Tensor) -> torch.Tensor:
+        pointer = int(X.data_ptr())
+        context = self.context_lookup.get(pointer)
+        if context is None:
+            raise ValueError(
+                "Unable to resolve DiCoFlex context for tensor with pointer "
+                f"{pointer}. Ensure the numpy array passed to metrics is the "
+                "same object used during registration."
+            )
+        return context
+
+    def __getattr__(self, name: str):
+        """Delegate attribute access to the wrapped model when needed."""
+        if name in {"base_model", "context_lookup"}:
+            return super().__getattr__(name)
+        return getattr(self.base_model, name)

--- a/cel/cf_methods/local_methods/dicoflex/data.py
+++ b/cel/cf_methods/local_methods/dicoflex/data.py
@@ -1,0 +1,482 @@
+"""Data utilities for the DiCoFlex counterfactual method."""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset, random_split
+
+from cel.datasets.base import MonotonicityDirection
+from cel.datasets.method_dataset import MethodDataset
+
+logger = logging.getLogger(__name__)
+
+
+def build_actionability_mask(
+    dataset: MethodDataset,
+    extra_actionable: Optional[Iterable[str]] = None,
+) -> np.ndarray:
+    """Construct a mask that highlights actionable features in the preprocessed space.
+
+    Args:
+        dataset: MethodDataset instance with fitted preprocessing pipeline.
+        extra_actionable: Additional feature names to treat as actionable
+            beyond those declared on the dataset (e.g., features subject to
+            a monotonic override that must be mutable for DiCoFlex even if
+            the shared dataset config marks them as frozen).
+
+    Returns:
+        np.ndarray: Vector with shape (n_features,) where actionable positions are set to 1.
+    """
+    n_features = dataset.X_train.shape[1]
+    mask = np.zeros(n_features, dtype=np.float32)
+    actionable = set(dataset.actionable_features or [])
+    if extra_actionable:
+        actionable.update(extra_actionable)
+
+    # Numerical features retain a one-to-one mapping after preprocessing.
+    for feature_name, feature_idx in zip(
+        dataset.numerical_features, dataset.numerical_features_indices
+    ):
+        if feature_name in actionable:
+            mask[feature_idx] = 1.0
+
+    # Categorical features might expand via one-hot encoding. We rely on the helper
+    # that exposes one-hot groups and fall back to raw indices if unavailable.
+    categorical_groups: Iterable[Sequence[int]]
+    try:
+        categorical_groups = dataset.categorical_features_lists
+    except (AttributeError, ValueError):
+        categorical_groups = dataset.categorical_features_indices
+
+    if categorical_groups:
+        if (
+            isinstance(categorical_groups, list)
+            and categorical_groups
+            and isinstance(categorical_groups[0], list)
+        ):
+            cat_groups_iter = categorical_groups
+        else:
+            cat_groups_iter = [
+                [int(index)] if isinstance(index, (int, np.integer)) else [int(i) for i in index]
+                for index in categorical_groups
+            ]
+
+        for feature_name, indices in zip(dataset.categorical_features, cat_groups_iter):
+            if feature_name in actionable:
+                mask[np.array(indices, dtype=int)] = 1.0
+
+    if not np.any(mask):
+        # Fall back to allowing all features if no actionable metadata is available.
+        mask[:] = 1.0
+    return mask
+
+
+def build_monotonic_direction_vector(
+    dataset: MethodDataset,
+    overrides: Optional[Dict[str, str]] = None,
+) -> np.ndarray:
+    """Build a per-feature direction vector for monotonic constraints.
+
+    Entries are +1 for features that may only increase (INCREASE), -1 for
+    features that may only decrease (DECREASE), and 0 for unconstrained
+    features. Only numerical features are considered; direction on one-hot
+    categorical expansions has no natural meaning and is ignored.
+
+    Args:
+        dataset: MethodDataset instance with fitted preprocessing pipeline.
+        overrides: Optional mapping of feature name to direction string
+            ("INCREASE" / "DECREASE"), evaluated in addition to any
+            dataset-level `monotonic_features` metadata. Overrides take
+            precedence when a feature appears in both sources.
+
+    Returns:
+        np.ndarray: Int8 vector of shape (n_features,).
+    """
+    n_features = dataset.X_train.shape[1]
+    direction_vec = np.zeros(n_features, dtype=np.int8)
+    combined: Dict[str, MonotonicityDirection] = {}
+    for name, direction in (dataset.monotonic_features or {}).items():
+        combined[name] = direction
+    for name, direction_str in (overrides or {}).items():
+        combined[name] = MonotonicityDirection(str(direction_str).upper())
+    if not combined:
+        return direction_vec
+    for feature_name, feature_idx in zip(
+        dataset.numerical_features, dataset.numerical_features_indices
+    ):
+        direction = combined.get(feature_name)
+        if direction is MonotonicityDirection.INCREASE:
+            direction_vec[feature_idx] = 1
+        elif direction is MonotonicityDirection.DECREASE:
+            direction_vec[feature_idx] = -1
+    return direction_vec
+
+
+@dataclass
+class DiCoFlexDatasetConfig:
+    """Container describing how to assemble the DiCoFlex training dataset."""
+
+    masks: List[np.ndarray]
+    p_values: List[float]
+    n_neighbors: int
+    noise_level: float
+    factual_chunk_size: int | None = None
+    target_chunk_size: int | None = None
+    seed: int | None = None
+    # Boolean mask over rows of X: only True rows may serve as neighbor TARGETS
+    # (the counterfactual points the flow is trained to reproduce). Factuals are
+    # unaffected. None means every row is eligible. Mirrors the reproduction's
+    # prob_threshold filter, which drops target candidates the classifier is not
+    # confident about.
+    target_eligibility: np.ndarray | None = None
+
+
+class DiCoFlexTrainingDataset(Dataset):
+    """Pairs factual points with nearby counterfactual targets for flow training."""
+
+    def __init__(
+        self,
+        X: np.ndarray,
+        y: np.ndarray,
+        config: DiCoFlexDatasetConfig,
+        numerical_indices: Sequence[int],
+        categorical_indices: Sequence[int],
+    ) -> None:
+        if X.shape[0] != y.shape[0]:
+            raise ValueError("X and y must contain the same number of samples.")
+        if not config.masks:
+            raise ValueError("At least one mask vector must be provided.")
+        self.X = X.astype(np.float32)
+        self.y = y.astype(int).reshape(-1)
+        self.n_features = self.X.shape[1]
+        self.masks = [self._prepare_mask(mask) for mask in config.masks]
+        self.p_values = [float(p) for p in config.p_values]
+        self.n_neighbors = max(1, config.n_neighbors)
+        self.noise_level = max(0.0, config.noise_level)
+        self._rng = np.random.default_rng(config.seed)
+        self.numerical_indices = np.array(numerical_indices, dtype=int)
+        self.categorical_indices = np.array(categorical_indices, dtype=int)
+        self.classes = np.unique(self.y)
+        if len(self.classes) < 2:
+            raise ValueError("DiCoFlex requires at least two classes.")
+        self.class_to_index: Dict[int, int] = {cls: idx for idx, cls in enumerate(self.classes)}
+        self.total_candidates = max(
+            self.n_neighbors * max(len(self.classes) - 1, 1), self.n_neighbors
+        )
+        self.factual_chunk_size = (
+            max(1, config.factual_chunk_size) if config.factual_chunk_size else 512
+        )
+        self.target_chunk_size = (
+            max(1, config.target_chunk_size) if config.target_chunk_size else 1024
+        )
+        # Pre-separate data by class to reduce memory usage during neighbor computation
+        self._X_by_class: Dict[int, np.ndarray] = {}
+        self._indices_by_class: Dict[int, np.ndarray] = {}
+        # Target-side pools, possibly thinned by config.target_eligibility.
+        self._X_target_by_class: Dict[int, np.ndarray] = {}
+        self._target_indices_by_class: Dict[int, np.ndarray] = {}
+        eligibility = (
+            None
+            if config.target_eligibility is None
+            else np.asarray(config.target_eligibility, dtype=bool).reshape(-1)
+        )
+        if eligibility is not None and eligibility.shape[0] != self.X.shape[0]:
+            raise ValueError("target_eligibility must have one entry per row of X.")
+        for cls in self.classes:
+            class_mask = self.y == cls
+            self._X_by_class[cls] = self.X[class_mask]
+            self._indices_by_class[cls] = np.where(class_mask)[0]
+            target_mask = class_mask if eligibility is None else class_mask & eligibility
+            if not np.any(target_mask):
+                logger.warning(
+                    "target_eligibility removed every point of class %s; "
+                    "falling back to the full class as neighbor targets.",
+                    cls,
+                )
+                target_mask = class_mask
+            self._X_target_by_class[cls] = self.X[target_mask]
+            self._target_indices_by_class[cls] = np.where(target_mask)[0]
+        self._neighbor_map = self._precompute_neighbors()
+        self._factual_entries = self._build_factual_entries()
+        if not self._factual_entries:
+            raise ValueError(
+                "Failed to build DiCoFlex training pairs. "
+                "Please check the masks, p-values, or n_neighbors configuration."
+            )
+
+    @property
+    def context_dim(self) -> int:
+        """Return the dimensionality of the conditioning vector."""
+        return self.n_features + len(self.classes) + self.n_features + 1
+
+    @property
+    def mask_vectors(self) -> List[np.ndarray]:
+        """Expose the validated mask vectors."""
+        return self.masks
+
+    def __len__(self) -> int:
+        return len(self._factual_entries)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        mask_idx, p_value, factual_idx, neighbor_records = self._factual_entries[idx]
+        factual = self.X[factual_idx]
+        cf_samples: List[np.ndarray] = []
+        contexts: List[np.ndarray] = []
+        for cf_idx, target_class in neighbor_records:
+            counterfactual = self._apply_noise(self.X[cf_idx].copy())
+            cf_samples.append(counterfactual.astype(np.float32))
+
+            class_one_hot = np.zeros(len(self.classes), dtype=np.float32)
+            class_idx = self.class_to_index[target_class]
+            class_one_hot[class_idx] = 1.0
+            context_vec = np.concatenate(
+                [
+                    factual,
+                    class_one_hot,
+                    self.masks[mask_idx],
+                    np.array([p_value], dtype=np.float32),
+                ],
+                axis=0,
+            ).astype(np.float32)
+            contexts.append(context_vec)
+
+        return torch.from_numpy(np.stack(cf_samples)), torch.from_numpy(np.stack(contexts))
+
+    def _prepare_mask(self, mask: np.ndarray) -> np.ndarray:
+        vector = np.asarray(mask, dtype=np.float32).reshape(-1)
+        if vector.shape[0] != self.n_features:
+            raise ValueError(
+                f"Mask length {vector.shape[0]} does not match feature dimension {self.n_features}."
+            )
+        return vector
+
+    def _precompute_neighbors(self) -> Dict[Tuple[int, float, int, int], np.ndarray]:
+        """Compute nearest neighbors using class-separated, chunked distance computation.
+
+        Distances are computed between factual/target class subsets in chunks, reducing
+        peak memory usage while still selecting the closest candidates.
+        """
+        neighbor_map: Dict[Tuple[int, float, int, int], np.ndarray] = {}
+        for mask_idx, mask in enumerate(self.masks):
+            for p_value in self.p_values:
+                for factual_class in self.classes:
+                    X_factual = self._X_by_class[factual_class]
+
+                    for target_class in self.classes:
+                        if target_class == factual_class:
+                            # Skip same-class pairs (counterfactuals must be different class)
+                            continue
+
+                        X_target = self._X_target_by_class[target_class]
+                        target_global_indices = self._target_indices_by_class[target_class]
+
+                        if X_target.size == 0:
+                            continue
+
+                        neighbor_global_ids = self._compute_neighbors_chunked(
+                            X_factual=X_factual,
+                            X_target=X_target,
+                            target_global_indices=target_global_indices,
+                            mask=mask,
+                            p_value=p_value,
+                        )
+                        neighbor_map[(mask_idx, p_value, factual_class, target_class)] = (
+                            neighbor_global_ids
+                        )
+
+        return neighbor_map
+
+    def _compute_neighbors_chunked(
+        self,
+        X_factual: np.ndarray,
+        X_target: np.ndarray,
+        target_global_indices: np.ndarray,
+        mask: np.ndarray,
+        p_value: float,
+    ) -> np.ndarray:
+        max_neighbors = min(self.total_candidates, X_target.shape[0])
+        factual_chunk = min(self.factual_chunk_size, X_factual.shape[0])
+        target_chunk = min(self.target_chunk_size, X_target.shape[0])
+        neighbor_global_ids = np.empty(
+            (X_factual.shape[0], max_neighbors), dtype=target_global_indices.dtype
+        )
+        mask_weight = mask.reshape(1, 1, -1)
+
+        for start in range(0, X_factual.shape[0], factual_chunk):
+            end = min(start + factual_chunk, X_factual.shape[0])
+            factual_block = X_factual[start:end]
+            best_dists = np.full(
+                (factual_block.shape[0], max_neighbors),
+                np.inf,
+                dtype=np.float32,
+            )
+            best_indices = np.full(
+                (factual_block.shape[0], max_neighbors),
+                -1,
+                dtype=target_global_indices.dtype,
+            )
+
+            for t_start in range(0, X_target.shape[0], target_chunk):
+                t_end = min(t_start + target_chunk, X_target.shape[0])
+                target_block = X_target[t_start:t_end]
+                diff = np.abs(factual_block[:, None, :] - target_block[None, :, :]) ** p_value
+                diff *= mask_weight
+                distances = np.sum(diff, axis=2) ** (1.0 / p_value)
+
+                target_ids = target_global_indices[t_start:t_end]
+                combined_dists = np.concatenate([best_dists, distances], axis=1)
+                combined_indices = np.concatenate(
+                    [
+                        best_indices,
+                        np.broadcast_to(target_ids, distances.shape),
+                    ],
+                    axis=1,
+                )
+                partition = np.argpartition(combined_dists, max_neighbors - 1, axis=1)[
+                    :, :max_neighbors
+                ]
+                best_dists = np.take_along_axis(combined_dists, partition, axis=1)
+                best_indices = np.take_along_axis(combined_indices, partition, axis=1)
+
+            order = np.argsort(best_dists, axis=1)
+            neighbor_global_ids[start:end] = np.take_along_axis(best_indices, order, axis=1)
+
+        return neighbor_global_ids
+
+    def _build_factual_entries(
+        self,
+    ) -> List[Tuple[int, float, int, List[Tuple[int, int]]]]:
+        """Build training entries pairing factual points with their nearest counterfactuals.
+
+        Iterates by class to align with the class-separated neighbor map structure.
+        """
+        entries: List[Tuple[int, float, int, List[Tuple[int, int]]]] = []
+
+        # Iterate by factual class to match the neighbor map's class-separated structure
+        for factual_class in self.classes:
+            factual_global_indices = self._indices_by_class[factual_class]
+
+            for local_factual_idx, factual_idx in enumerate(factual_global_indices):
+                for mask_idx, _ in enumerate(self.masks):
+                    for p_value in self.p_values:
+                        neighbor_records: List[Tuple[int, int]] = []
+
+                        for target_class in self.classes:
+                            if target_class == factual_class:
+                                continue
+
+                            key = (mask_idx, p_value, factual_class, target_class)
+                            if key not in self._neighbor_map:
+                                continue
+
+                            # Use local index to access the neighbor map
+                            neighbor_indices = self._neighbor_map[key][local_factual_idx]
+                            neighbor_records.extend(
+                                [(cf_idx, target_class) for cf_idx in neighbor_indices]
+                            )
+
+                        if not neighbor_records:
+                            continue
+
+                        if len(neighbor_records) < self.n_neighbors:
+                            repeats = math.ceil(self.n_neighbors / len(neighbor_records))
+                            neighbor_records = (neighbor_records * repeats)[: self.n_neighbors]
+                        else:
+                            neighbor_records = neighbor_records[: self.n_neighbors]
+
+                        entries.append((mask_idx, p_value, factual_idx, neighbor_records))
+
+        return entries
+
+    def _apply_noise(self, sample: np.ndarray) -> np.ndarray:
+        if self.noise_level > 0 and self.numerical_indices.size > 0:
+            sample[self.numerical_indices] += self._rng.normal(
+                0.0,
+                self.noise_level,
+                size=self.numerical_indices.size,
+            ).astype(np.float32)
+        if self.noise_level > 0 and self.categorical_indices.size > 0:
+            sample[self.categorical_indices] += self._rng.normal(
+                0.0,
+                self.noise_level * 0.1,
+                size=self.categorical_indices.size,
+            ).astype(np.float32)
+        return sample
+
+
+def create_dicoflex_dataloaders(
+    X: np.ndarray,
+    y: np.ndarray,
+    masks: List[np.ndarray],
+    p_values: List[float],
+    n_neighbors: int,
+    noise_level: float,
+    factual_batch_size: int,
+    val_ratio: float,
+    seed: int,
+    numerical_indices: Sequence[int],
+    categorical_indices: Sequence[int],
+    factual_chunk_size: int | None = None,
+    target_chunk_size: int | None = None,
+    target_eligibility: np.ndarray | None = None,
+) -> Tuple[DataLoader, DataLoader, Dict[int, int], List[np.ndarray], int]:
+    """Create train/validation loaders for DiCoFlex flow training.
+
+    Args:
+        factual_chunk_size: Chunk size for factual samples in neighbor search.
+        target_chunk_size: Chunk size for target samples in neighbor search.
+        target_eligibility: Optional boolean row mask; only True rows may serve
+            as neighbor targets (see DiCoFlexDatasetConfig.target_eligibility).
+    """
+    config = DiCoFlexDatasetConfig(
+        masks=masks,
+        p_values=p_values,
+        n_neighbors=n_neighbors,
+        noise_level=noise_level,
+        factual_chunk_size=factual_chunk_size,
+        target_chunk_size=target_chunk_size,
+        seed=seed,
+        target_eligibility=target_eligibility,
+    )
+    dataset = DiCoFlexTrainingDataset(
+        X=X,
+        y=y,
+        config=config,
+        numerical_indices=numerical_indices,
+        categorical_indices=categorical_indices,
+    )
+    if len(dataset) < 2:
+        raise ValueError("Not enough training pairs to train DiCoFlex flow.")
+    val_size = max(1, int(len(dataset) * val_ratio))
+    if val_size >= len(dataset):
+        val_size = max(1, len(dataset) // 5)
+    train_size = len(dataset) - val_size
+    if train_size <= 0:
+        raise ValueError("Validation split is too large for the available DiCoFlex training pairs.")
+    generator = torch.Generator().manual_seed(seed)
+    train_subset, val_subset = random_split(dataset, [train_size, val_size], generator=generator)
+    train_loader = DataLoader(
+        train_subset,
+        batch_size=factual_batch_size,
+        shuffle=True,
+        drop_last=False,
+    )
+    val_loader = DataLoader(
+        val_subset,
+        batch_size=factual_batch_size,
+        shuffle=False,
+        drop_last=False,
+    )
+    return (
+        train_loader,
+        val_loader,
+        dataset.class_to_index,
+        dataset.mask_vectors,
+        dataset.context_dim,
+    )

--- a/cel/cf_methods/local_methods/dicoflex/data.py
+++ b/cel/cf_methods/local_methods/dicoflex/data.py
@@ -126,6 +126,11 @@ class DiCoFlexDatasetConfig:
     p_values: List[float]
     n_neighbors: int
     noise_level: float
+    # Fixed sigma of the Gaussian noise on one-hot categorical columns of the
+    # counterfactual targets. The reproduction uses 0.08 regardless of
+    # noise_level; without it the flow's density collapses onto the discrete
+    # one-hot corners and sampling misses them.
+    categorical_noise_level: float = 0.08
     factual_chunk_size: int | None = None
     target_chunk_size: int | None = None
     seed: int | None = None
@@ -159,6 +164,7 @@ class DiCoFlexTrainingDataset(Dataset):
         self.p_values = [float(p) for p in config.p_values]
         self.n_neighbors = max(1, config.n_neighbors)
         self.noise_level = max(0.0, config.noise_level)
+        self.categorical_noise_level = max(0.0, config.categorical_noise_level)
         self._rng = np.random.default_rng(config.seed)
         self.numerical_indices = np.array(numerical_indices, dtype=int)
         self.categorical_indices = np.array(categorical_indices, dtype=int)
@@ -225,7 +231,7 @@ class DiCoFlexTrainingDataset(Dataset):
 
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         mask_idx, p_value, factual_idx, neighbor_records = self._factual_entries[idx]
-        factual = self.X[factual_idx]
+        factual = self._noised_condition(self.X[factual_idx])
         cf_samples: List[np.ndarray] = []
         contexts: List[np.ndarray] = []
         for cf_idx, target_class in neighbor_records:
@@ -401,13 +407,29 @@ class DiCoFlexTrainingDataset(Dataset):
                 self.noise_level,
                 size=self.numerical_indices.size,
             ).astype(np.float32)
-        if self.noise_level > 0 and self.categorical_indices.size > 0:
+        if self.categorical_noise_level > 0 and self.categorical_indices.size > 0:
             sample[self.categorical_indices] += self._rng.normal(
                 0.0,
-                self.noise_level * 0.1,
+                self.categorical_noise_level,
                 size=self.categorical_indices.size,
             ).astype(np.float32)
         return sample
+
+    def _noised_condition(self, factual: np.ndarray) -> np.ndarray:
+        """Return the conditioning copy of a factual with numeric jitter.
+
+        The reproduction perturbs the numeric part of the conditioning vector
+        with a tenth of the target noise, so the flow generalises over nearby
+        factuals instead of memorising the exact training points.
+        """
+        conditioned = factual.copy()
+        if self.noise_level > 0 and self.numerical_indices.size > 0:
+            conditioned[self.numerical_indices] += self._rng.normal(
+                0.0,
+                self.noise_level / 10.0,
+                size=self.numerical_indices.size,
+            ).astype(np.float32)
+        return conditioned
 
 
 def create_dicoflex_dataloaders(
@@ -417,6 +439,7 @@ def create_dicoflex_dataloaders(
     p_values: List[float],
     n_neighbors: int,
     noise_level: float,
+    categorical_noise_level: float,
     factual_batch_size: int,
     val_ratio: float,
     seed: int,
@@ -439,6 +462,7 @@ def create_dicoflex_dataloaders(
         p_values=p_values,
         n_neighbors=n_neighbors,
         noise_level=noise_level,
+        categorical_noise_level=categorical_noise_level,
         factual_chunk_size=factual_chunk_size,
         target_chunk_size=target_chunk_size,
         seed=seed,

--- a/cel/cf_methods/local_methods/dicoflex/method.py
+++ b/cel/cf_methods/local_methods/dicoflex/method.py
@@ -1,0 +1,334 @@
+"""Implementation of the DiCoFlex counterfactual method."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+
+from cel.cf_methods.counterfactual_base import (
+    BaseCounterfactualMethod,
+    ExplanationResult,
+)
+from cel.cf_methods.local_counterfactual_mixin import (
+    LocalCounterfactualMixin,
+)
+from cel.models.generative_mixin import GenerativePytorchMixin
+from cel.models.pytorch_base import PytorchBase
+
+
+@dataclass
+class DiCoFlexParams:
+    """Container for inference-time DiCoFlex settings."""
+
+    mask_index: int
+    p_value: float
+    num_counterfactuals: int
+    target_class: Optional[int]
+    sampling_batch_size: int
+    cf_samples_per_factual: int = 1
+    temperature: float = 1.0
+
+
+class DiCoFlex(BaseCounterfactualMethod, LocalCounterfactualMixin):
+    """Sample-based counterfactual generator backed by a conditional flow."""
+
+    def __init__(
+        self,
+        gen_model: GenerativePytorchMixin,
+        disc_model: PytorchBase,
+        class_to_index: Dict[int, int],
+        mask_vectors: list[np.ndarray],
+        params: DiCoFlexParams,
+        device: Optional[str] = None,
+        monotonic_direction: Optional[np.ndarray] = None,
+    ) -> None:
+        super().__init__(
+            gen_model=gen_model,
+            disc_model=disc_model,
+            device=device,
+        )
+        if not mask_vectors:
+            raise ValueError("At least one mask vector must be supplied for DiCoFlex.")
+        if params.mask_index >= len(mask_vectors):
+            raise ValueError("mask_index exceeds available mask vectors.")
+        # target_class None means the target is the flip of each factual's own
+        # label, so there is no single class to check against here.
+        if params.target_class is not None and params.target_class not in class_to_index:
+            raise ValueError(
+                f"Target class {params.target_class} not observed in the training data."
+            )
+        self.class_to_index = class_to_index
+        self.mask_vectors = mask_vectors
+        self.params = params
+        self.device = device or "cpu"
+        n_features = mask_vectors[0].shape[0]
+        if monotonic_direction is None:
+            self.monotonic_direction = np.zeros(n_features, dtype=np.int8)
+        else:
+            direction_vec = np.asarray(monotonic_direction, dtype=np.int8).reshape(-1)
+            if direction_vec.shape[0] != n_features:
+                raise ValueError(
+                    f"monotonic_direction length {direction_vec.shape[0]} does not match "
+                    f"feature dimension {n_features}."
+                )
+            self.monotonic_direction = direction_vec
+        self.gen_model.to(self.device)
+        self.disc_model.to(self.device)
+
+    def explain(
+        self,
+        X: np.ndarray,
+        y_origin: np.ndarray,
+        y_target: np.ndarray,
+        X_train: Optional[np.ndarray] = None,
+        y_train: Optional[np.ndarray] = None,
+        **kwargs,
+    ) -> ExplanationResult:
+        """Generate counterfactuals for the provided samples."""
+        x_np = np.asarray(X, dtype=np.float32)
+        y_origin_vec = np.asarray(y_origin).reshape(-1, 1)
+        y_target_vec = np.asarray(y_target).reshape(-1, 1)
+        (
+            cf_batch,
+            y_target_flat,
+            x_orig_flat,
+            y_origin_flat,
+            target_probs,
+            valid_mask,
+            log_probs,
+            group_ids,
+        ) = self._sample_counterfactuals(x_np, y_origin_vec, y_target_vec)
+        logs = {
+            "sampling/mean_target_probability": float(target_probs.mean()),
+            "sampling/valid_ratio": float(valid_mask.mean()),
+            "sampling/log_prob_mean": float(log_probs.mean()),
+            "model_returned_mask": valid_mask.tolist(),
+            "cf_group_ids": group_ids.tolist(),
+        }
+        return ExplanationResult(
+            x_cfs=cf_batch,
+            y_cf_targets=y_target_flat,
+            x_origs=x_orig_flat,
+            y_origs=y_origin_flat,
+            logs=logs,
+            cf_group_ids=group_ids,
+        )
+
+    def explain_dataloader(
+        self,
+        dataloader,
+        **kwargs,
+    ) -> ExplanationResult:
+        """Adapter around explain() for DataLoader inputs."""
+        xs, ys = [], []
+        for batch_x, batch_y in dataloader:
+            xs.append(batch_x.numpy())
+            ys.append(batch_y.numpy())
+        X = np.vstack(xs)
+        y_origin = np.concatenate(ys)
+        if self.params.target_class is None:
+            y_target = np.abs(1 - y_origin)
+        else:
+            y_target = np.full_like(y_origin, fill_value=self.params.target_class)
+        return self.explain(
+            X=X,
+            y_origin=y_origin,
+            y_target=y_target,
+        )
+
+    def _sample_counterfactuals(
+        self, X: np.ndarray, y_origin: np.ndarray, y_target: np.ndarray
+    ) -> tuple[
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+        np.ndarray,
+    ]:
+        """Sample candidate counterfactuals and keep top-k per factual."""
+        batch_size = self.params.sampling_batch_size
+        k = max(1, self.params.cf_samples_per_factual)
+
+        flat_cf: list[np.ndarray] = []
+        flat_y_target: list[np.ndarray] = []
+        flat_x_orig: list[np.ndarray] = []
+        flat_y_origin: list[np.ndarray] = []
+        flat_probs: list[np.ndarray] = []
+        flat_valid: list[np.ndarray] = []
+        flat_log_probs: list[np.ndarray] = []
+        group_ids: list[int] = []
+        global_idx = 0
+
+        for start in range(0, len(X), batch_size):
+            end = start + batch_size
+            X_batch = X[start:end]
+            y_target_batch = y_target[start:end]
+            y_origin_batch = y_origin[start:end]
+            if X_batch.size == 0:
+                continue
+            context = self._build_context(X_batch, y_target_batch)
+            samples, log_probs = self.gen_model.sample_and_log_proba(
+                n_samples=self.params.num_counterfactuals,
+                context=context,
+                temp=self.params.temperature,
+            )
+
+            (
+                batch_selected_cf,
+                batch_selected_probs,
+                batch_selected_valid,
+                batch_selected_logs,
+            ) = self._select_topk_candidates(
+                X_batch=X_batch,
+                y_target_batch=y_target_batch,
+                candidates=samples,
+                candidate_log_probs=log_probs,
+                top_k=k,
+            )
+
+            batch_size_current = X_batch.shape[0]
+            flat_cf.append(batch_selected_cf.reshape(-1, samples.shape[-1]))
+            flat_probs.append(batch_selected_probs.reshape(-1))
+            flat_valid.append(batch_selected_valid.reshape(-1))
+            flat_log_probs.append(batch_selected_logs.reshape(-1))
+            flat_x_orig.append(np.repeat(X_batch, k, axis=0))
+            flat_y_target.append(np.repeat(y_target_batch, k, axis=0))
+            flat_y_origin.append(np.repeat(y_origin_batch, k, axis=0))
+            group_ids.extend(np.repeat(np.arange(global_idx, global_idx + batch_size_current), k))
+            global_idx += batch_size_current
+
+        return (
+            np.vstack(flat_cf),
+            np.vstack(flat_y_target),
+            np.vstack(flat_x_orig),
+            np.vstack(flat_y_origin),
+            np.concatenate(flat_probs),
+            np.concatenate(flat_valid),
+            np.concatenate(flat_log_probs),
+            np.array(group_ids, dtype=int),
+        )
+
+    def _check_monotonic_constraints(
+        self, X_batch: np.ndarray, candidates: np.ndarray
+    ) -> np.ndarray:
+        """Return a (batch, num_samples) bool matrix marking direction-compliant candidates.
+
+        Features with direction_vec == +1 must not decrease; direction_vec == -1 must not
+        increase. A small numerical tolerance permits equality under float noise.
+        """
+        direction = self.monotonic_direction
+        active_idx = np.where(direction != 0)[0]
+        if active_idx.size == 0:
+            return np.ones(candidates.shape[:2], dtype=bool)
+        tol = 1e-6
+        factual_sub = X_batch[:, active_idx][:, None, :]
+        candidate_sub = candidates[:, :, active_idx]
+        signs = direction[active_idx].astype(np.float32)
+        delta = (candidate_sub - factual_sub) * signs[None, None, :]
+        return np.all(delta >= -tol, axis=2)
+
+    def _build_context(self, X: np.ndarray, y_target: np.ndarray) -> np.ndarray:
+        mask = self.mask_vectors[self.params.mask_index]
+        mask_matrix = np.repeat(mask[None, :], repeats=len(X), axis=0)
+        p_value_column = np.full((len(X), 1), fill_value=self.params.p_value, dtype=np.float32)
+        class_one_hot = np.zeros((len(X), len(self.class_to_index)), dtype=np.float32)
+        target_indices = np.vectorize(self.class_to_index.get, otypes=[int])(
+            y_target.reshape(-1).astype(int)
+        )
+        class_one_hot[np.arange(len(X)), target_indices] = 1.0
+        return np.concatenate([X, class_one_hot, mask_matrix, p_value_column], axis=1).astype(
+            np.float32
+        )
+
+    def _select_topk_candidates(
+        self,
+        X_batch: np.ndarray,
+        y_target_batch: np.ndarray,
+        candidates: np.ndarray,
+        candidate_log_probs: np.ndarray,
+        top_k: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        batch_size, num_samples, _ = candidates.shape
+        flat_candidates = candidates.reshape(batch_size * num_samples, -1)
+        # The flow occasionally samples non-finite or astronomically large rows;
+        # they are dead candidates, and feeding them to the classifier crashes
+        # space-converting adapters (inverting minmax on a huge value overflows
+        # float32 to inf, which sklearn transforms reject). Legit generation-space
+        # values sit in ~[0, 1], so the magnitude bound is generous. Score only
+        # sane rows and mark the rest invalid below.
+        finite_rows = np.isfinite(flat_candidates).all(axis=1) & (
+            np.abs(flat_candidates) < 1e6
+        ).all(axis=1)
+        if finite_rows.all():
+            flat_probs = self.disc_model.predict_proba(flat_candidates)
+        elif finite_rows.any():
+            finite_probs = self.disc_model.predict_proba(flat_candidates[finite_rows])
+            flat_probs = np.zeros(
+                (flat_candidates.shape[0], finite_probs.shape[1]), dtype=finite_probs.dtype
+            )
+            flat_probs[finite_rows] = finite_probs
+        else:
+            flat_probs = np.zeros(
+                (flat_candidates.shape[0], len(self.class_to_index)), dtype=np.float32
+            )
+        probs = flat_probs.reshape(batch_size, num_samples, -1)
+        num_classes = probs.shape[-1]
+        target_indices = np.vectorize(self.class_to_index.get, otypes=[int])(
+            y_target_batch.reshape(-1).astype(int)
+        )
+        if np.any(target_indices >= num_classes):
+            raise ValueError("Target class index exceeds discriminator outputs.")
+        expanded_targets = np.repeat(target_indices[:, None], num_samples, axis=1)
+        target_probs = np.take_along_axis(probs, expanded_targets[..., None], axis=2).squeeze(2)
+        predicted_class = np.argmax(probs, axis=2)
+        valid_mask_matrix = predicted_class == target_indices[:, None]
+        # A zero-filled prob row argmaxes to class 0, which would wrongly count
+        # as valid whenever the target is 0 — exclude non-finite rows explicitly.
+        valid_mask_matrix &= finite_rows.reshape(batch_size, num_samples)
+
+        if np.any(self.monotonic_direction != 0):
+            monotonic_ok = self._check_monotonic_constraints(X_batch, candidates)
+            valid_mask_matrix = valid_mask_matrix & monotonic_ok
+
+        # Rank candidates by PROXIMITY to the factual (closest first), not by
+        # classifier confidence. Ranking by ``-target_probs`` prefers the samples
+        # the classifier is most sure about, which sit deepest in the target
+        # region and are therefore the FARTHEST from the factual — the opposite
+        # of what a counterfactual should be. The reference DiCoFlex / DICTUM
+        # select by distance to the factual, so we do too. L1 over all
+        # (generation-space) features matches the Prox.-Cont metric's cityblock
+        # form; validity is still enforced first via ``valid_mask_matrix`` below.
+        distances = np.abs(candidates - X_batch[:, None, :]).sum(axis=2)
+        sorted_indices = np.argsort(distances, axis=1)
+        top_indices = np.zeros((batch_size, top_k), dtype=int)
+        for i in range(batch_size):
+            chosen: list[int] = []
+            for idx in sorted_indices[i]:
+                if valid_mask_matrix[i, idx]:
+                    chosen.append(idx)
+                if len(chosen) == top_k:
+                    break
+            if len(chosen) < top_k:
+                for idx in sorted_indices[i]:
+                    if idx not in chosen:
+                        chosen.append(idx)
+                    if len(chosen) == top_k:
+                        break
+            if not chosen:
+                fallback = sorted_indices[i][0] if sorted_indices[i].size else 0
+                chosen = [int(fallback)]
+            if len(chosen) < top_k:
+                chosen.extend([chosen[-1]] * (top_k - len(chosen)))
+            top_indices[i] = np.array(chosen[:top_k])
+
+        row_selector = np.arange(batch_size)[:, None]
+        selected_cf = candidates[row_selector, top_indices]
+        selected_probs = target_probs[row_selector, top_indices]
+        selected_valid = valid_mask_matrix[row_selector, top_indices]
+        selected_logs = candidate_log_probs[row_selector, top_indices]
+        return selected_cf, selected_probs, selected_valid, selected_logs

--- a/cel/cf_methods/local_methods/dicoflex/visualization.py
+++ b/cel/cf_methods/local_methods/dicoflex/visualization.py
@@ -1,0 +1,227 @@
+"""Visualization helpers for DiCoFlex training and inference."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+
+from .context_utils import build_context_matrix
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _ensure_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def visualize_training_batch(
+    batch_cf: torch.Tensor,
+    batch_context: torch.Tensor,
+    feature_names: Sequence[str],
+    save_path: Path,
+    max_points: int | None = 200,
+    dataset_points: np.ndarray | None = None,
+) -> None:
+    """Plot an entire training batch of factual points with their sampled neighbours."""
+    if batch_cf.shape[1] < 2:
+        LOGGER.info("Skipping training-batch visualization (need at least 2 features).")
+        return
+
+    factuals = batch_context[:, : batch_cf.shape[1]].cpu().numpy()
+    neighbors = batch_cf.cpu().numpy()
+    total = neighbors.shape[0]
+    if max_points is not None and total > max_points:
+        rng = np.random.default_rng(0)
+        idx = rng.choice(total, size=max_points, replace=False)
+        neighbors = neighbors[idx]
+        factuals = factuals[idx]
+
+    plt.figure(figsize=(6, 5))
+    if dataset_points is not None and dataset_points.shape[1] >= 2:
+        plt.scatter(
+            dataset_points[:, 0],
+            dataset_points[:, 1],
+            c="lightgray",
+            alpha=0.2,
+            label="Dataset",
+            edgecolors="none",
+        )
+    plt.scatter(
+        neighbors[:, 0],
+        neighbors[:, 1],
+        c="tab:blue",
+        alpha=0.6,
+        label="Neighbour samples",
+        edgecolors="none",
+    )
+    plt.scatter(
+        factuals[:, 0],
+        factuals[:, 1],
+        c="tab:orange",
+        marker="*",
+        s=60,
+        label="Factual points",
+        edgecolor="k",
+    )
+    plt.title("Training batch (factuals vs neighbours)")
+    x_label = feature_names[0] if feature_names else "feature_0"
+    y_label = feature_names[1] if len(feature_names) > 1 else "feature_1"
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    plt.legend()
+    plt.tight_layout()
+    _ensure_dir(save_path)
+    plt.savefig(save_path, dpi=200)
+    plt.close()
+
+
+def visualize_flow_contours(
+    gen_model: torch.nn.Module,
+    factual_point: np.ndarray,
+    target_label: int,
+    mask_vector: np.ndarray,
+    p_value: float,
+    class_to_index: dict[int, int],
+    feature_bounds: Sequence[tuple[float, float]],
+    save_path: Path,
+    feature_names: Sequence[str] | None = None,
+    grid_size: int = 200,
+    device: str = "cpu",
+    dataset_points: np.ndarray | None = None,
+) -> None:
+    """Plot contour lines of the trained flow's log-density around a factual point."""
+    if factual_point.shape[0] < 2:
+        LOGGER.info("Skipping contour visualization (need at least 2 features).")
+        return
+
+    (x_min, x_max), (y_min, y_max) = feature_bounds
+    grid_x = np.linspace(x_min, x_max, grid_size)
+    grid_y = np.linspace(y_min, y_max, grid_size)
+    mesh_x, mesh_y = np.meshgrid(grid_x, grid_y)
+
+    repeated = np.repeat(factual_point[np.newaxis, :], grid_size**2, axis=0)
+    repeated[:, 0] = mesh_x.ravel()
+    repeated[:, 1] = mesh_y.ravel()
+    contexts = build_context_matrix(
+        factual_points=np.repeat(factual_point[np.newaxis, :], grid_size**2, axis=0),
+        labels=np.full(grid_size**2, target_label),
+        mask_vector=mask_vector,
+        p_value=p_value,
+        class_to_index=class_to_index,
+    )
+    with torch.no_grad():
+        scores = (
+            gen_model(
+                torch.from_numpy(repeated).float().to(device),
+                context=contexts.to(device),
+            )
+            .cpu()
+            .numpy()
+            .reshape(grid_size, grid_size)
+        )
+    scores = np.clip(scores, a_min=-10.0, a_max=None)
+
+    plt.figure(figsize=(6, 5))
+    contour = plt.contour(
+        mesh_x,
+        mesh_y,
+        scores,
+        levels=20,
+        cmap="viridis",
+    )
+    plt.clabel(contour, inline=True, fontsize=8)
+    plt.colorbar(contour, label="log p(x | factual)")
+    if dataset_points is not None and dataset_points.shape[1] >= 2:
+        plt.scatter(
+            dataset_points[:, 0],
+            dataset_points[:, 1],
+            c="lightgray",
+            alpha=0.2,
+            label="Dataset",
+            edgecolors="none",
+        )
+    plt.scatter(
+        factual_point[0],
+        factual_point[1],
+        c="red",
+        marker="*",
+        s=120,
+        edgecolor="k",
+        label="Factual",
+    )
+    x_label = feature_names[0] if feature_names else "feature_0"
+    y_label = feature_names[1] if feature_names and len(feature_names) > 1 else "feature_1"
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    plt.title("DiCoFlex flow log-density contour")
+    plt.legend(loc="upper right")
+    plt.tight_layout()
+    _ensure_dir(save_path)
+    plt.savefig(save_path, dpi=200)
+    plt.close()
+
+
+def visualize_counterfactual_samples(
+    factual_points: np.ndarray,
+    counterfactual_points: np.ndarray,
+    feature_names: Sequence[str],
+    save_path: Path,
+    dataset_points: np.ndarray | None = None,
+    max_points: int = 200,
+) -> None:
+    """Plot sampled counterfactuals alongside their factual anchors."""
+    if factual_points.shape[1] < 2:
+        LOGGER.info("Skipping counterfactual scatter (need at least 2 features).")
+        return
+
+    total_points = factual_points.shape[0]
+    if total_points > max_points:
+        idx = np.random.default_rng(0).choice(total_points, size=max_points, replace=False)
+        factual_points = factual_points[idx]
+        counterfactual_points = counterfactual_points[idx]
+
+    plt.figure(figsize=(6, 5))
+    if dataset_points is not None and dataset_points.shape[1] >= 2:
+        plt.scatter(
+            dataset_points[:, 0],
+            dataset_points[:, 1],
+            c="lightgray",
+            alpha=0.2,
+            label="Dataset",
+            edgecolors="none",
+        )
+    plt.scatter(
+        counterfactual_points[:, 0],
+        counterfactual_points[:, 1],
+        c="tab:green",
+        alpha=0.7,
+        label="Counterfactuals",
+        edgecolors="none",
+    )
+    plt.scatter(
+        factual_points[:, 0],
+        factual_points[:, 1],
+        c="tab:orange",
+        marker="*",
+        s=60,
+        label="Factuals",
+        edgecolor="k",
+    )
+    x_label = feature_names[0] if feature_names else "feature_0"
+    y_label = feature_names[1] if len(feature_names) > 1 else "feature_1"
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    plt.title("Sampled counterfactuals")
+    plt.legend()
+    plt.tight_layout()
+    _ensure_dir(save_path)
+    plt.savefig(save_path, dpi=200)
+    plt.close()

--- a/cel/datasets/method_dataset.py
+++ b/cel/datasets/method_dataset.py
@@ -182,6 +182,14 @@ class MethodDataset:
         return self.file_dataset.actionable_features
 
     @property
+    def monotonic_features(self):
+        """Return a mapping of feature name to :class:`MonotonicityDirection`.
+
+        Datasets that declare no monotonic constraints yield an empty mapping.
+        """
+        return getattr(self.file_dataset, "monotonic_features", {}) or {}
+
+    @property
     def config(self):
         """Return dataset configuration."""
         return self.file_dataset.config

--- a/cel/models/generative/maf/maf.py
+++ b/cel/models/generative/maf/maf.py
@@ -140,17 +140,56 @@ class MaskedAutoregressiveFlow(PytorchBase, GenerativePytorchMixin):
         assert len(dataloader.dataset) == len(results)
         return results
 
-    def sample_and_log_proba(self, n_samples: int, context: np.ndarray | None = None):
-        """Sample from the model and return (samples, log_probs) as numpy arrays."""
+    def sample_and_log_proba(
+        self, n_samples: int, context: np.ndarray | None = None, temp: float = 1.0
+    ):
+        """Sample from the model and return (samples, log_probs) as numpy arrays.
+
+        Args:
+            n_samples: Number of samples to draw per context row.
+            context: Optional conditioning context.
+            temp: Sampling temperature. The base Gaussian noise is scaled by
+                ``temp`` before the inverse transform, mirroring the original
+                DiCoFlex flow (``ofurman/DiCoFlex``, ``generative_models/maf.py``).
+                ``temp < 1`` shrinks the base draw toward the mean, which bounds
+                the sampled tail; ``temp == 1.0`` reproduces the stock nflows path.
+
+        Returns:
+            Tuple of (samples, log_probs) as numpy arrays.
+        """
+        model_device = next(self.model.parameters()).device
         if context is not None and self.context_features is not None:
             if isinstance(context, np.ndarray):
                 context = torch.from_numpy(context).float()
-            context = context.view(-1, self.context_features)
+            context = context.view(-1, self.context_features).to(model_device)
         self.eval()
         with torch.no_grad():
-            samples, log_probs = self.model.sample_and_log_prob(
-                num_samples=n_samples, context=context
-            )
+            if temp == 1.0:
+                samples, log_probs = self.model.sample_and_log_prob(
+                    num_samples=n_samples, context=context
+                )
+                return samples.cpu().numpy(), log_probs.cpu().numpy()
+
+            # Temperature path: replicate nflows Flow._sample but scale the base
+            # noise by ``temp`` before the inverse transform.
+            from nflows.utils import torchutils
+
+            flow = self.model
+            embedded_context = flow._embedding_net(context)
+            noise = flow._distribution.sample(n_samples, context=embedded_context)
+            noise = noise * temp
+            if embedded_context is not None:
+                noise = torchutils.merge_leading_dims(noise, num_dims=2)
+                context_repeat = torchutils.repeat_rows(embedded_context, num_reps=n_samples)
+            else:
+                context_repeat = None
+            samples, _ = flow._transform.inverse(noise, context=context_repeat)
+            # Log-prob of the actually-produced samples (used only for logging /
+            # plausibility, never for selection).
+            log_probs = flow.log_prob(samples, context=context_repeat)
+            if embedded_context is not None:
+                samples = torchutils.split_leading_dim(samples, shape=[-1, n_samples])
+                log_probs = torchutils.split_leading_dim(log_probs, shape=[-1, n_samples])
             return samples.cpu().numpy(), log_probs.cpu().numpy()
 
     def predict_log_proba(

--- a/cel/models/pytorch_base.py
+++ b/cel/models/pytorch_base.py
@@ -26,19 +26,19 @@ class PytorchBase(torch.nn.Module, ABC):
         self.num_inputs = num_inputs
         self.num_targets = num_targets
 
-    @staticmethod
-    def _to_tensor(X: np.ndarray | torch.Tensor) -> torch.Tensor:
-        """Convert numpy array to float32 tensor if needed.
+    def _to_tensor(self, X: np.ndarray | torch.Tensor) -> torch.Tensor:
+        """Convert input to a float32 tensor on the model's device.
 
         Args:
             X: Input data as numpy array or tensor.
 
         Returns:
-            Float32 tensor.
+            Float32 tensor on the same device as the model parameters, so
+            prediction helpers keep working after the model is moved to GPU.
         """
         if isinstance(X, np.ndarray):
-            return torch.from_numpy(X).float()
-        return X
+            X = torch.from_numpy(X).float()
+        return X.to(next(self.parameters()).device)
 
     def save(self, path: str) -> None:
         """Save model state to file."""

--- a/cel/models/pytorch_base.py
+++ b/cel/models/pytorch_base.py
@@ -45,8 +45,13 @@ class PytorchBase(torch.nn.Module, ABC):
         torch.save(self.state_dict(), path)
 
     def load(self, path: str) -> None:
-        """Load model state from file."""
-        self.load_state_dict(torch.load(path))
+        """Load model state from file onto the device the model currently lives on.
+
+        The explicit ``map_location`` lets a checkpoint trained on GPU be loaded
+        into a CPU-resident model (and vice versa), which the train-on-GPU /
+        generate-on-CPU split relies on.
+        """
+        self.load_state_dict(torch.load(path, map_location=next(self.parameters()).device))
 
     @abstractmethod
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/cel/pipelines/base_runner.py
+++ b/cel/pipelines/base_runner.py
@@ -155,7 +155,10 @@ class PipelineRunner(ABC):
 
     def run(self) -> None:
         """Orchestrate the full pipeline across all CV folds."""
-        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+        # Hide the GPU unless a run asks for it, so the default stays CPU-only
+        # as before. Methods that train their own model can then use it.
+        if not self.cfg.experiment.get("use_gpu", False):
+            os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
         self.logger.info("Loading dataset")
         dataset = self.load_dataset()
         dequantizer = GroupDequantizer(dataset.categorical_features_lists)

--- a/cel/pipelines/conf/dicoflex_config.yaml
+++ b/cel/pipelines/conf/dicoflex_config.yaml
@@ -18,8 +18,10 @@ experiment:
   output_folder: models/
   relabel_with_disc_model: true
   seed: 42
-  # Flow training benefits from a GPU; every other stage is cheap. Left off so
-  # the default run behaves like the other pipelines.
+  # GPU accelerates flow training only; the trained flow moves back to CPU and
+  # generation, the classifier, and metrics all run on CPU. Checkpoints are
+  # written CPU-loadable. Off by default so the run behaves like the other
+  # pipelines.
   use_gpu: false
   # Clip numeric columns to the MinMax training box before scoring. The flow is
   # bounded in practice by the sampling temperature but not in principle, and a

--- a/cel/pipelines/conf/dicoflex_config.yaml
+++ b/cel/pipelines/conf/dicoflex_config.yaml
@@ -7,7 +7,7 @@
 # Please do not "tidy" them without rerunning the sanity check.
 defaults:
   - _self_
-  - gen_model: large_maf
+  - gen_model: orig_maf
   - disc_model: mlp
 
 hydra:
@@ -70,6 +70,10 @@ counterfactuals_params:
   neighbor_prob_threshold: 0.55
   n_neighbors: 32
   noise_level: 0.01
+  # Fixed sigma of the noise on one-hot categorical target columns; the
+  # reproduction uses 0.08 independent of noise_level. The conditioning
+  # factual's numeric columns are additionally jittered with noise_level/10.
+  categorical_noise_level: 0.08
   p_values: [2.0]
   train_batch_factuals: 4
   val_ratio: 0.2

--- a/cel/pipelines/conf/dicoflex_config.yaml
+++ b/cel/pipelines/conf/dicoflex_config.yaml
@@ -54,7 +54,12 @@ counterfactuals_params:
     _target_: cel.cf_methods.DiCoFlex
 
   log_prob_quantile: 0.25
-  target_class: 0
+  # null flips each factual's own label so one run covers both directions;
+  # an integer pushes every factual to that class.
+  target_class: null
+  # Seeded cap on the number of explained test rows, for comparable metrics and
+  # bounded runtime. null explains every eligible row.
+  n_test_samples: 2000
   batch_size: 4096
 
   # Neighbour mining: each factual is paired with its nearest target-class

--- a/cel/pipelines/conf/dicoflex_config.yaml
+++ b/cel/pipelines/conf/dicoflex_config.yaml
@@ -1,0 +1,79 @@
+# DiCoFlex on the standard five-fold cross-validation protocol.
+#
+# The counterfactuals_params below are experimental findings, not defaults.
+# They come from the reproduction of brinpow/dicoflex_repro and are what makes
+# the conditional flow usable at all; sampling at full variance with the stock
+# hyperparameters produces numeric proximity of order 1e17 and infinite LOF.
+# Please do not "tidy" them without rerunning the sanity check.
+defaults:
+  - _self_
+  - gen_model: large_maf
+  - disc_model: mlp
+
+hydra:
+  sweeper:
+    max_batch_size: 1
+
+experiment:
+  output_folder: models/
+  relabel_with_disc_model: true
+  seed: 42
+  # Flow training benefits from a GPU; every other stage is cheap. Left off so
+  # the default run behaves like the other pipelines.
+  use_gpu: false
+  # Clip numeric columns to the MinMax training box before scoring. The flow is
+  # bounded in practice by the sampling temperature but not in principle, and a
+  # few far samples otherwise dominate the mean-based proximity metrics.
+  clamp_numeric_to_box: true
+
+dataset:
+  _target_: cel.datasets.FileDataset
+  config_path: config/datasets/bank_marketing.yaml
+
+disc_model:
+  train_model: true
+  epochs: 100
+  batch_size: 64
+  patience: 15
+  lr: 0.001
+
+gen_model:
+  train_model: true
+  # The flow is trained to convergence under early stopping rather than to a
+  # fixed epoch count; an undertrained flow was the identified cause of poor
+  # target coverage.
+  epochs: 10000
+  patience: 50
+  batch_size: 256
+  lr: 0.001
+
+counterfactuals_params:
+  cf_method:
+    _target_: cel.cf_methods.DiCoFlex
+
+  log_prob_quantile: 0.25
+  target_class: 0
+  batch_size: 4096
+
+  # Neighbour mining: each factual is paired with its nearest target-class
+  # points, so the flow learns to generate nearby counterfactuals.
+  n_neighbors: 32
+  noise_level: 0.01
+  p_values: [2.0]
+  train_batch_factuals: 4
+  val_ratio: 0.2
+
+  # Sampling. temperature < 1 shrinks the flow's base Gaussian draw, which is
+  # the mechanism that bounds the sampled tail.
+  temperature: 0.8
+  num_counterfactuals: 100
+  cf_samples_per_factual: 100
+  sampling_batch_size: 256
+
+  # Candidates are ranked closest-valid-first, so the leading counterfactual of
+  # each block is the one metrics read.
+  inference_mask_index: 0
+  inference_p_value: 2.0
+  use_actionability_mask: false
+  custom_masks: []
+  monotonic_overrides: {}

--- a/cel/pipelines/conf/dicoflex_config.yaml
+++ b/cel/pipelines/conf/dicoflex_config.yaml
@@ -58,7 +58,11 @@ counterfactuals_params:
   batch_size: 4096
 
   # Neighbour mining: each factual is paired with its nearest target-class
-  # points, so the flow learns to generate nearby counterfactuals.
+  # points, so the flow learns to generate nearby counterfactuals. Targets are
+  # additionally restricted to training points the classifier assigns at least
+  # neighbor_prob_threshold probability for their own class (reference
+  # prob_threshold=0.55); 0 disables the filter.
+  neighbor_prob_threshold: 0.55
   n_neighbors: 32
   noise_level: 0.01
   p_values: [2.0]

--- a/cel/pipelines/conf/disc_model/mlp_small.yaml
+++ b/cel/pipelines/conf/disc_model/mlp_small.yaml
@@ -1,0 +1,4 @@
+model:
+  _target_: cel.models.classifier.multilayer_perceptron.MLPClassifier
+  hidden_layer_sizes: [32, 32]
+  dropout: 0.2

--- a/cel/pipelines/conf/gen_model/orig_maf.yaml
+++ b/cel/pipelines/conf/gen_model/orig_maf.yaml
@@ -1,0 +1,9 @@
+# The conditional-flow architecture of the original DiCoFlex implementation
+# (ofurman/DiCoFlex, brinpow/dicoflex_repro): wide and shallow. Used as the
+# METHOD's generation flow; density-estimation models elsewhere in the library
+# keep their own configs.
+model:
+  _target_: cel.models.generative.maf.maf.MaskedAutoregressiveFlow
+  hidden_features: 64
+  num_blocks_per_layer: 2
+  num_layers: 5

--- a/cel/pipelines/nodes/factual_selection.py
+++ b/cel/pipelines/nodes/factual_selection.py
@@ -1,0 +1,74 @@
+"""Shared selection of the factual instances a run explains.
+
+Every counterfactual pipeline has to answer the same two questions before it
+generates anything: which test rows get explained, and what target class each of
+them is pushed towards. Keeping the answer here means DiCE, CCHVAE and DiCoFlex
+select identical query sets for identical settings, which is what makes their
+metrics comparable.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def select_factual_indices(
+    y_test: np.ndarray,
+    target_class: Optional[int],
+    n_test_samples: Optional[int] = None,
+    seed: int = 42,
+) -> np.ndarray:
+    """Choose which test rows to explain.
+
+    Args:
+        y_test: Test labels, already relabelled by the discriminator if the
+            experiment does that.
+        target_class: The class counterfactuals are pushed towards. Rows already
+            in that class are dropped, since flipping them is a no-op. When None,
+            no row is dropped and both flip directions are covered in one run.
+        n_test_samples: Optional cap on the number of explained rows, drawn
+            without replacement. None explains every eligible row.
+        seed: Seed for the subsample. A dedicated generator is used rather than
+            the global NumPy state, so the query set depends only on this seed
+            and not on how much randomness the pipeline consumed beforehand.
+
+    Returns:
+        Sorted array of indices into `y_test`.
+    """
+    if target_class is None:
+        indices = np.arange(len(y_test))
+    else:
+        indices = np.flatnonzero(y_test != target_class)
+
+    if n_test_samples is not None and 0 < n_test_samples < len(indices):
+        rng = np.random.default_rng(seed)
+        indices = np.sort(rng.choice(indices, size=n_test_samples, replace=False))
+
+    logger.info(
+        "Explaining %d test rows (target_class=%s, n_test_samples=%s)",
+        len(indices),
+        target_class,
+        n_test_samples,
+    )
+    return indices
+
+
+def resolve_target_labels(y_factual: np.ndarray, target_class: Optional[int]) -> np.ndarray:
+    """Return the desired class for each factual.
+
+    Args:
+        y_factual: Labels of the selected factuals.
+        target_class: Fixed target class, or None to flip each factual's own
+            label (binary tasks only).
+
+    Returns:
+        Array of target labels aligned with `y_factual`.
+    """
+    if target_class is None:
+        return np.abs(1 - y_factual)
+    return np.full_like(y_factual, fill_value=target_class)

--- a/cel/pipelines/nodes/seeding.py
+++ b/cel/pipelines/nodes/seeding.py
@@ -1,0 +1,36 @@
+"""Global RNG seeding for reproducible pipeline runs."""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+
+import numpy as np
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def set_global_seed(seed: int, *, deterministic_torch: bool = False) -> None:
+    """Seed every RNG the pipelines draw from.
+
+    Seeding torch alone is not sufficient. DiCE's ``random`` generation method
+    and the group dequantizer both draw from the NumPy global RNG, and several
+    dataset helpers use the stdlib ``random`` module, so a run seeded only
+    through ``torch.manual_seed`` varies uncontrollably between repetitions.
+
+    Args:
+        seed: Seed applied to ``random``, NumPy and torch.
+        deterministic_torch: Also force deterministic cuDNN kernels. Slower,
+            and unnecessary while the traintest pipelines pin themselves to CPU.
+    """
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    if deterministic_torch:
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+    logger.info("Global seed set to %s", seed)

--- a/cel/pipelines/run_dicoflex_pipeline.py
+++ b/cel/pipelines/run_dicoflex_pipeline.py
@@ -3,6 +3,7 @@ import logging
 import hydra
 from omegaconf import DictConfig
 
+from cel.pipelines.nodes.seeding import set_global_seed
 from cel.pipelines.runners.dicoflex_runner import DiCoFlexPipelineRunner
 from cel.preprocessing import (
     MinMaxScalingStep,
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 @hydra.main(config_path="./conf", config_name="dicoflex_config", version_base="1.2")
 def main(cfg: DictConfig):
+    set_global_seed(cfg.experiment.get("seed", 42))
     preprocessing_pipeline = PreprocessingPipeline(
         [
             ("minmax", MinMaxScalingStep()),

--- a/cel/pipelines/run_dicoflex_pipeline.py
+++ b/cel/pipelines/run_dicoflex_pipeline.py
@@ -1,0 +1,29 @@
+import logging
+
+import hydra
+from omegaconf import DictConfig
+
+from cel.pipelines.runners.dicoflex_runner import DiCoFlexPipelineRunner
+from cel.preprocessing import (
+    MinMaxScalingStep,
+    PreprocessingPipeline,
+    TorchDataTypeStep,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@hydra.main(config_path="./conf", config_name="dicoflex_config", version_base="1.2")
+def main(cfg: DictConfig):
+    preprocessing_pipeline = PreprocessingPipeline(
+        [
+            ("minmax", MinMaxScalingStep()),
+            ("torch_dtype", TorchDataTypeStep()),
+        ]
+    )
+    runner = DiCoFlexPipelineRunner(cfg, logger, preprocessing_pipeline)
+    runner.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/cel/pipelines/runners/__init__.py
+++ b/cel/pipelines/runners/__init__.py
@@ -25,6 +25,7 @@ _RUNNERS = {
     "CEMPipelineRunner": "cel.pipelines.runners.cem_runner",
     "CETPipelineRunner": "cel.pipelines.runners.cet_runner",
     "DiCEPipelineRunner": "cel.pipelines.runners.dice_runner",
+    "DiCoFlexPipelineRunner": "cel.pipelines.runners.dicoflex_runner",
     "GLANCEPipelineRunner": "cel.pipelines.runners.glance_runner",
     "GLOBECEPipelineRunner": "cel.pipelines.runners.globe_ce_runner",
     "GroupGLOBECEPipelineRunner": "cel.pipelines.runners.group_globe_ce_runner",

--- a/cel/pipelines/runners/dicoflex_runner.py
+++ b/cel/pipelines/runners/dicoflex_runner.py
@@ -1,0 +1,507 @@
+"""Pipeline runner for the DiCoFlex counterfactual method.
+
+DiCoFlex conditions a normalising flow on ``[factual, target class, mask, p]`` and
+samples counterfactuals directly, so it departs from the plain generative-model
+contract in three ways that the hooks below implement:
+
+* the flow is conditional and trains on mined factual/neighbour pairs rather than
+  on the raw training matrix, so :meth:`DiCoFlexPipelineRunner.create_gen_model`
+  builds its own dataloaders and training loop;
+* the plausibility threshold is therefore computed over those same context-carrying
+  batches;
+* metrics need the context that produced each row, supplied by
+  :class:`DiCoFlexGeneratorMetricsAdapter`.
+
+The dataloaders built during training are reused at inference (they carry the
+class index map and the mask catalogue), so they are kept on the instance between
+hook calls.
+"""
+
+import logging
+from typing import Any
+
+import numpy as np
+import torch
+import torch.utils.data
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+
+from cel.cf_methods.local_methods.dicoflex import DiCoFlex, DiCoFlexParams
+from cel.cf_methods.local_methods.dicoflex.context_utils import (
+    DiCoFlexGeneratorMetricsAdapter,
+    build_context_matrix,
+    get_numpy_pointer,
+)
+from cel.cf_methods.local_methods.dicoflex.data import (
+    build_actionability_mask,
+    build_monotonic_direction_vector,
+    create_dicoflex_dataloaders,
+)
+from cel.datasets.method_dataset import MethodDataset
+from cel.dequantization.dequantizer import GroupDequantizer
+from cel.metrics.metrics import evaluate_cf
+from cel.pipelines.base_runner import CfMethodOutput, PipelineRunner, SearchResult
+from cel.pipelines.utils import apply_categorical_discretization
+
+logger = logging.getLogger(__name__)
+
+# Generation-space values live in ~[0, 1]; anything past this bound is a dead
+# flow sample whose inverse transform would overflow float32.
+_OVERFLOW_BOUND = 1e6
+
+
+def build_masks(dataset: MethodDataset, cf_params: DictConfig) -> list[np.ndarray]:
+    """Assemble the mask catalogue used during DiCoFlex training.
+
+    Args:
+        dataset: Dataset the masks are built against.
+        cf_params: The ``counterfactuals_params`` config node.
+
+    Returns:
+        List of mask vectors, each of length ``n_features``. Falls back to a
+        single all-ones mask when no mask is configured.
+
+    Raises:
+        ValueError: If a custom mask length does not match the feature dimension.
+    """
+    masks: list[np.ndarray] = []
+    monotonic_overrides = dict(cf_params.get("monotonic_overrides") or {})
+    if cf_params.use_actionability_mask:
+        masks.append(build_actionability_mask(dataset, extra_actionable=monotonic_overrides.keys()))
+    for custom_mask in cf_params.get("custom_masks", []):
+        mask_vec = np.asarray(custom_mask, dtype=np.float32).reshape(-1)
+        if mask_vec.shape[0] != dataset.X_train.shape[1]:
+            raise ValueError(
+                "Custom mask length does not match the feature dimension after preprocessing."
+            )
+        masks.append(mask_vec)
+    if not masks:
+        masks.append(np.ones(dataset.X_train.shape[1], dtype=np.float32))
+    return masks
+
+
+def train_dicoflex_generator(
+    model: torch.nn.Module,
+    train_loader: torch.utils.data.DataLoader,
+    val_loader: torch.utils.data.DataLoader,
+    cfg: DictConfig,
+    model_path: str,
+    device: torch.device,
+) -> None:
+    """Train the conditional flow with early stopping on the validation loss.
+
+    The best checkpoint is written to ``model_path`` as it improves and reloaded
+    once training ends, so the caller always holds the best-scoring weights.
+
+    Args:
+        model: Conditional flow to train.
+        train_loader: Loader over mined factual/neighbour pairs.
+        val_loader: Held-out slice of the same pairs.
+        cfg: Full pipeline config; reads ``gen_model.{lr,epochs,patience,eps}``.
+        model_path: Where the best checkpoint is written.
+        device: Device to train on.
+    """
+    optimizer = torch.optim.Adam(model.parameters(), lr=cfg.gen_model.lr)
+    best_val = float("inf")
+    patience_counter = 0
+    eps = cfg.gen_model.get("eps", 1e-5)
+
+    for epoch in range(cfg.gen_model.epochs):
+        model.train()
+        train_loss = 0.0
+        for batch_cf, batch_context in train_loader:
+            batch_cf = batch_cf.reshape(-1, batch_cf.shape[-1]).to(device)
+            batch_context = batch_context.reshape(-1, batch_context.shape[-1]).to(device)
+            optimizer.zero_grad()
+            loss = -model(batch_cf, context=batch_context).mean()
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item()
+        train_loss /= max(1, len(train_loader))
+
+        model.eval()
+        val_loss = 0.0
+        with torch.no_grad():
+            for batch_cf, batch_context in val_loader:
+                batch_cf = batch_cf.reshape(-1, batch_cf.shape[-1]).to(device)
+                batch_context = batch_context.reshape(-1, batch_context.shape[-1]).to(device)
+                val_loss += (-model(batch_cf, context=batch_context).mean()).item()
+        val_loss /= max(1, len(val_loader))
+        logger.info("Epoch %s | train loss %.4f | val loss %.4f", epoch, train_loss, val_loss)
+
+        if val_loss < best_val - eps:
+            best_val = val_loss
+            patience_counter = 0
+            model.save(model_path)
+        else:
+            patience_counter += 1
+            if patience_counter > cfg.gen_model.patience:
+                logger.info("Early stopping after %s epochs", epoch + 1)
+                break
+
+    model.load(model_path)
+
+
+def flow_log_prob_threshold(
+    model: torch.nn.Module,
+    dataloader: torch.utils.data.DataLoader,
+    quantile: float,
+    device: torch.device,
+) -> float:
+    """Estimate a plausibility threshold from training log probabilities.
+
+    Args:
+        model: Trained conditional flow.
+        dataloader: Loader over the full set of training pairs.
+        quantile: Quantile of the log-probability distribution to cut at.
+        device: Device the flow lives on.
+
+    Returns:
+        The log-probability value at ``quantile``.
+    """
+    log_probs = []
+    model.eval()
+    with torch.no_grad():
+        for batch_cf, batch_context in dataloader:
+            batch_cf = batch_cf.reshape(-1, batch_cf.shape[-1]).to(device)
+            batch_context = batch_context.reshape(-1, batch_context.shape[-1]).to(device)
+            log_probs.append(model(batch_cf, context=batch_context).cpu())
+    return torch.quantile(torch.cat(log_probs), quantile).item()
+
+
+def full_training_loader(
+    subset_loader: torch.utils.data.DataLoader, batch_size: int
+) -> torch.utils.data.DataLoader:
+    """Create a loader over the complete DiCoFlex dataset behind a train split.
+
+    Args:
+        subset_loader: The training loader, whose dataset may be a ``Subset``.
+        batch_size: Batch size for the new loader.
+
+    Returns:
+        A loader iterating every mined pair, train and validation alike.
+    """
+    base_dataset = (
+        subset_loader.dataset.dataset
+        if hasattr(subset_loader.dataset, "dataset")
+        else subset_loader.dataset
+    )
+    return torch.utils.data.DataLoader(base_dataset, batch_size=batch_size, shuffle=False)
+
+
+class DiCoFlexPipelineRunner(PipelineRunner):
+    """Pipeline runner for DiCoFlex counterfactual generation."""
+
+    cf_method_name = "DiCoFlex"
+
+    def __init__(
+        self, cfg: DictConfig, logger: logging.Logger, preprocessing_pipeline=None
+    ) -> None:
+        """Initialise the runner and resolve the training device.
+
+        Args:
+            cfg: Hydra configuration for the pipeline run.
+            logger: Logger instance for structured output.
+            preprocessing_pipeline: Preprocessing applied to the dataset.
+        """
+        super().__init__(cfg, logger, preprocessing_pipeline)
+        use_gpu = cfg.experiment.get("use_gpu", False)
+        self.device = torch.device("cuda" if use_gpu and torch.cuda.is_available() else "cpu")
+        self._flow: torch.nn.Module | None = None
+        self._train_loader: torch.utils.data.DataLoader | None = None
+        self._class_to_index: dict[int, int] = {}
+        self._mask_vectors: list[np.ndarray] = []
+
+    def create_gen_model(
+        self, dataset: MethodDataset, path: str, dequantizer: GroupDequantizer
+    ) -> torch.nn.Module:
+        """Mine factual/neighbour pairs and train the conditional flow on them.
+
+        The dequantizer is unused: DiCoFlex trains on mined pairs in the model
+        space rather than on dequantized rows.
+
+        Args:
+            dataset: The current fold's dataset.
+            path: Path used to save/load the flow checkpoint.
+            dequantizer: Unused, kept for the base-class signature.
+
+        Returns:
+            The trained conditional flow.
+        """
+        cf_params = self.cfg.counterfactuals_params
+        masks = build_masks(dataset, cf_params)
+        (
+            self._train_loader,
+            val_loader,
+            self._class_to_index,
+            self._mask_vectors,
+            context_dim,
+        ) = create_dicoflex_dataloaders(
+            dataset.X_train,
+            dataset.y_train,
+            masks=masks,
+            p_values=list(cf_params.p_values),
+            n_neighbors=cf_params.n_neighbors,
+            noise_level=cf_params.noise_level,
+            factual_batch_size=cf_params.train_batch_factuals,
+            val_ratio=cf_params.val_ratio,
+            seed=self.cfg.experiment.get("seed", 42),
+            numerical_indices=dataset.numerical_features_indices,
+            categorical_indices=dataset.categorical_features_indices,
+            factual_chunk_size=cf_params.get("neighbor_factual_chunk_size"),
+            target_chunk_size=cf_params.get("neighbor_target_chunk_size"),
+        )
+
+        gen_model = instantiate(
+            self.cfg.gen_model.model,
+            features=dataset.X_train.shape[1],
+            context_features=context_dim,
+        ).to(self.device)
+
+        if self.cfg.gen_model.train_model:
+            train_dicoflex_generator(
+                gen_model, self._train_loader, val_loader, self.cfg, path, self.device
+            )
+        else:
+            gen_model.load(path)
+        self._flow = gen_model
+        return gen_model
+
+    def compute_log_prob_threshold(
+        self,
+        gen_model: torch.nn.Module,
+        dataset: MethodDataset,
+        dequantizer: GroupDequantizer,
+    ) -> float:
+        """Compute the plausibility threshold over the mined training pairs.
+
+        Args:
+            gen_model: The trained conditional flow.
+            dataset: The current fold's dataset (unused).
+            dequantizer: Unused, kept for the base-class signature.
+
+        Returns:
+            Scalar log-probability threshold at the configured quantile.
+        """
+        cf_params = self.cfg.counterfactuals_params
+        loader = full_training_loader(self._train_loader, cf_params.train_batch_factuals)
+        threshold = flow_log_prob_threshold(
+            gen_model, loader, cf_params.log_prob_quantile, self.device
+        )
+        self.logger.info(f"log_prob_threshold: {threshold:.4f}")
+        return threshold
+
+    def search_counterfactuals(
+        self,
+        dataset: MethodDataset,
+        gen_model: torch.nn.Module,
+        disc_model: torch.nn.Module,
+        save_folder: str,
+        log_prob_threshold: float,
+    ) -> SearchResult:
+        """Generate counterfactuals for the current fold.
+
+        Args:
+            dataset: The current fold's dataset.
+            gen_model: Trained conditional flow.
+            disc_model: Trained discriminative model.
+            save_folder: Directory for saving generated counterfactuals.
+            log_prob_threshold: Plausibility threshold.
+
+        Returns:
+            :class:`SearchResult` with counterfactuals and timing information.
+        """
+        return self._default_search_counterfactuals(
+            dataset, gen_model, disc_model, save_folder, log_prob_threshold
+        )
+
+    def create_cf_method(
+        self,
+        dataset: MethodDataset,
+        gen_model: torch.nn.Module,
+        disc_model: torch.nn.Module,
+    ) -> DiCoFlex:
+        """Instantiate DiCoFlex over the trained flow and classifier.
+
+        Args:
+            dataset: The current fold's dataset.
+            gen_model: Trained conditional flow.
+            disc_model: Trained discriminative model.
+
+        Returns:
+            The configured :class:`DiCoFlex` instance.
+        """
+        cf_params = self.cfg.counterfactuals_params
+        params = DiCoFlexParams(
+            mask_index=cf_params.inference_mask_index,
+            p_value=cf_params.inference_p_value,
+            num_counterfactuals=cf_params.num_counterfactuals,
+            target_class=cf_params.target_class,
+            sampling_batch_size=cf_params.sampling_batch_size,
+            cf_samples_per_factual=cf_params.cf_samples_per_factual,
+            temperature=cf_params.get("temperature", 1.0),
+        )
+        monotonic_overrides = dict(cf_params.get("monotonic_overrides") or {})
+        monotonic_direction = build_monotonic_direction_vector(
+            dataset, overrides=monotonic_overrides
+        )
+        if np.any(monotonic_direction != 0):
+            self.logger.info(
+                "Monotonic constraints active on %d feature(s). Overrides: %s",
+                int(np.sum(monotonic_direction != 0)),
+                monotonic_overrides,
+            )
+        return DiCoFlex(
+            gen_model=gen_model,
+            disc_model=disc_model,
+            class_to_index=self._class_to_index,
+            mask_vectors=self._mask_vectors,
+            params=params,
+            device=str(self.device),
+            monotonic_direction=monotonic_direction,
+        )
+
+    def run_cf_method(
+        self,
+        cf_method: DiCoFlex,
+        cf_dataloader: torch.utils.data.DataLoader,
+        dataset: MethodDataset,
+        log_prob_threshold: float,
+    ) -> CfMethodOutput:
+        """Sample counterfactuals for every filtered test row.
+
+        Args:
+            cf_method: The DiCoFlex instance.
+            cf_dataloader: Loader over the filtered test set.
+            dataset: The current fold's dataset.
+            log_prob_threshold: Plausibility threshold (unused by DiCoFlex).
+
+        Returns:
+            :class:`CfMethodOutput` with one block of counterfactuals per factual.
+        """
+        X_test = np.concatenate([batch[0].numpy() for batch in cf_dataloader])
+        y_test = np.concatenate([batch[1].numpy() for batch in cf_dataloader])
+        target_class = self._get_target_class()
+        y_target = np.full(y_test.shape[0], target_class, dtype=y_test.dtype)
+
+        result = cf_method.explain(X=X_test, y_origin=y_test, y_target=y_target)
+        model_returned = np.asarray(result.logs.get("model_returned_mask", []), dtype=bool)
+        if model_returned.size == 0:
+            model_returned = np.ones(result.x_cfs.shape[0], dtype=bool)
+
+        return CfMethodOutput(
+            x_cfs=np.ascontiguousarray(result.x_cfs, dtype=np.float32),
+            x_origs=np.ascontiguousarray(result.x_origs, dtype=np.float32),
+            y_origs=result.y_origs,
+            y_targets=result.y_cf_targets,
+            model_returned=model_returned,
+        )
+
+    def postprocess_cf_output(
+        self, output: CfMethodOutput, dataset: MethodDataset
+    ) -> CfMethodOutput:
+        """Repair dead samples, snap categoricals, and bound the numeric tail.
+
+        A flow sampled at temperature < 1 is bounded in practice but not in
+        principle, so the numeric columns are clipped to the training box the
+        MinMax model space defines. Without it a handful of far samples dominate
+        the mean-based proximity metrics.
+
+        Args:
+            output: Raw output from :meth:`run_cf_method`.
+            dataset: The current fold's dataset.
+
+        Returns:
+            The processed :class:`CfMethodOutput`.
+        """
+        x_cfs = output.x_cfs.copy()
+        dead = ~np.isfinite(x_cfs).all(axis=1) | (np.abs(x_cfs) >= _OVERFLOW_BOUND).any(axis=1)
+        if np.any(dead):
+            self.logger.info(
+                "Replacing %d failed counterfactual row(s) with the original factual",
+                int(np.sum(dead)),
+            )
+            x_cfs[dead] = output.x_origs[dead]
+
+        x_cfs = apply_categorical_discretization(dataset.categorical_features_lists, x_cfs)
+
+        if self.cfg.experiment.get("clamp_numeric_to_box", True):
+            num_idx = dataset.numerical_features_indices
+            if len(num_idx) > 0:
+                x_cfs[:, num_idx] = np.clip(x_cfs[:, num_idx], 0.0, 1.0)
+
+        output.x_cfs = x_cfs
+        return output
+
+    def calculate_metrics(
+        self,
+        gen_model: torch.nn.Module,
+        disc_model: torch.nn.Module,
+        dataset: MethodDataset,
+        result: SearchResult,
+        log_prob_threshold: float,
+    ) -> dict[str, Any]:
+        """Score the closest counterfactual of each factual.
+
+        DiCoFlex emits ``cf_samples_per_factual`` counterfactuals per query,
+        ordered closest-valid-first, so metrics read the leading row of each
+        block while the CSV keeps the full set.
+
+        Args:
+            gen_model: Dequantization-wrapped model from the base runner. It is
+                deliberately unused: that wrapper calls the flow without a
+                context, which a conditional flow cannot accept, so scoring goes
+                through the raw flow behind a context-aware adapter instead.
+            disc_model: Trained discriminative model.
+            dataset: The current fold's dataset.
+            result: Output of :meth:`search_counterfactuals`.
+            log_prob_threshold: Plausibility threshold.
+
+        Returns:
+            Dictionary of metric name to value.
+        """
+        cf_params = self.cfg.counterfactuals_params
+        stride = cf_params.cf_samples_per_factual
+        x_cf = np.ascontiguousarray(result.X_cf[::stride], dtype=np.float32)
+        x_orig = np.ascontiguousarray(result.X_test[::stride], dtype=np.float32)
+        y_orig = result.y_orig[::stride]
+        y_target = result.y_target[::stride]
+        model_returned = result.model_returned[::stride]
+
+        mask_vector = self._mask_vectors[cf_params.inference_mask_index]
+        context_lookup = {
+            get_numpy_pointer(x_cf): build_context_matrix(
+                factual_points=x_orig,
+                labels=y_target,
+                mask_vector=mask_vector,
+                p_value=cf_params.inference_p_value,
+                class_to_index=self._class_to_index,
+            ),
+            get_numpy_pointer(x_orig): build_context_matrix(
+                factual_points=x_orig,
+                labels=y_orig,
+                mask_vector=mask_vector,
+                p_value=cf_params.inference_p_value,
+                class_to_index=self._class_to_index,
+            ),
+        }
+
+        self.logger.info("Calculating metrics")
+        metrics = evaluate_cf(
+            disc_model=disc_model,
+            gen_model=DiCoFlexGeneratorMetricsAdapter(
+                base_model=self._flow, context_lookup=context_lookup
+            ),
+            X_cf=x_cf,
+            model_returned=model_returned,
+            categorical_features=dataset.categorical_features_indices,
+            continuous_features=dataset.numerical_features_indices,
+            X_train=dataset.X_train,
+            y_train=dataset.y_train.reshape(-1),
+            X_test=x_orig,
+            y_test=y_orig,
+            y_target=y_target,
+            median_log_prob=log_prob_threshold,
+        )
+        self.logger.info(f"Metrics:\n{metrics}")
+        return metrics

--- a/cel/pipelines/runners/dicoflex_runner.py
+++ b/cel/pipelines/runners/dicoflex_runner.py
@@ -41,6 +41,7 @@ from cel.datasets.method_dataset import MethodDataset
 from cel.dequantization.dequantizer import GroupDequantizer
 from cel.metrics.metrics import evaluate_cf
 from cel.pipelines.base_runner import CfMethodOutput, PipelineRunner, SearchResult
+from cel.pipelines.nodes.factual_selection import resolve_target_labels, select_factual_indices
 from cel.pipelines.utils import apply_categorical_discretization
 
 logger = logging.getLogger(__name__)
@@ -445,8 +446,9 @@ class DiCoFlexPipelineRunner(PipelineRunner):
         """
         X_test = np.concatenate([batch[0].numpy() for batch in cf_dataloader])
         y_test = np.concatenate([batch[1].numpy() for batch in cf_dataloader])
-        target_class = self._get_target_class()
-        y_target = np.full(y_test.shape[0], target_class, dtype=y_test.dtype)
+        # target_class None flips each factual's own label, so one run covers
+        # both directions; an integer pushes every factual to that class.
+        y_target = resolve_target_labels(y_test, self._get_target_class())
 
         result = cf_method.explain(X=X_test, y_origin=y_test, y_target=y_target)
         model_returned = np.asarray(result.logs.get("model_returned_mask", []), dtype=bool)
@@ -460,6 +462,30 @@ class DiCoFlexPipelineRunner(PipelineRunner):
             y_targets=result.y_cf_targets,
             model_returned=model_returned,
         )
+
+    def _filter_test_data(
+        self, dataset: MethodDataset, target_class: int | None
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Select the query set: seeded, optionally capped, both-direction aware.
+
+        Overrides the base filter so ``target_class: null`` explains every test
+        row towards its own flip, and ``n_test_samples`` caps the query set with
+        a dedicated generator, keeping it identical across reruns of a seed.
+
+        Args:
+            dataset: The current fold's dataset, already relabelled.
+            target_class: Fixed target class, or None for per-instance flips.
+
+        Returns:
+            Tuple of (X_test, y_test) restricted to the selected rows.
+        """
+        indices = select_factual_indices(
+            dataset.y_test,
+            target_class=target_class,
+            n_test_samples=self.cfg.counterfactuals_params.get("n_test_samples"),
+            seed=self.cfg.experiment.get("seed", 42),
+        )
+        return dataset.X_test[indices], dataset.y_test[indices]
 
     def postprocess_cf_output(
         self, output: CfMethodOutput, dataset: MethodDataset

--- a/cel/pipelines/runners/dicoflex_runner.py
+++ b/cel/pipelines/runners/dicoflex_runner.py
@@ -301,6 +301,7 @@ class DiCoFlexPipelineRunner(PipelineRunner):
             p_values=list(cf_params.p_values),
             n_neighbors=cf_params.n_neighbors,
             noise_level=cf_params.noise_level,
+            categorical_noise_level=cf_params.get("categorical_noise_level", 0.08),
             factual_batch_size=cf_params.train_batch_factuals,
             val_ratio=cf_params.val_ratio,
             seed=self.cfg.experiment.get("seed", 42),

--- a/cel/pipelines/runners/dicoflex_runner.py
+++ b/cel/pipelines/runners/dicoflex_runner.py
@@ -215,9 +215,59 @@ class DiCoFlexPipelineRunner(PipelineRunner):
             "cuda" if use_gpu and torch.cuda.is_available() else "cpu"
         )
         self._flow: torch.nn.Module | None = None
+        self._disc_model: torch.nn.Module | None = None
         self._train_loader: torch.utils.data.DataLoader | None = None
         self._class_to_index: dict[int, int] = {}
         self._mask_vectors: list[np.ndarray] = []
+
+    def create_disc_model(
+        self, dataset: MethodDataset, path: str, save_folder: str
+    ) -> torch.nn.Module:
+        """Create the classifier and keep a handle for the neighbour filter.
+
+        Args:
+            dataset: The current fold's dataset.
+            path: Path used to save/load the model checkpoint.
+            save_folder: Directory for auxiliary outputs.
+
+        Returns:
+            Trained discriminative model.
+        """
+        self._disc_model = super().create_disc_model(dataset, path, save_folder)
+        return self._disc_model
+
+    def _neighbor_target_eligibility(self, dataset: MethodDataset) -> np.ndarray | None:
+        """Mask of training points confident enough to serve as neighbour targets.
+
+        Mirrors the reference implementation's ``prob_threshold``: a training
+        point may be mined as a neighbour target only when the classifier
+        assigns its (relabeled) class at least ``neighbor_prob_threshold``
+        probability, so the flow learns to land in confidently-classified
+        regions. A threshold of 0 disables the filter.
+
+        Args:
+            dataset: The current fold's dataset, already relabeled.
+
+        Returns:
+            Boolean mask over the training rows, or None when disabled.
+        """
+        threshold = float(
+            self.cfg.counterfactuals_params.get("neighbor_prob_threshold", 0.0) or 0.0
+        )
+        if threshold <= 0.0 or self._disc_model is None:
+            return None
+        train_probs = self._disc_model.predict_proba(dataset.X_train)
+        own_class_conf = np.take_along_axis(
+            train_probs, dataset.y_train.reshape(-1, 1).astype(int), axis=1
+        ).reshape(-1)
+        eligibility = own_class_conf >= threshold
+        self.logger.info(
+            "Neighbor target filter: %d of %d training points pass prob >= %.2f",
+            int(eligibility.sum()),
+            len(eligibility),
+            threshold,
+        )
+        return eligibility
 
     def create_gen_model(
         self, dataset: MethodDataset, path: str, dequantizer: GroupDequantizer
@@ -257,6 +307,7 @@ class DiCoFlexPipelineRunner(PipelineRunner):
             categorical_indices=dataset.categorical_features_indices,
             factual_chunk_size=cf_params.get("neighbor_factual_chunk_size"),
             target_chunk_size=cf_params.get("neighbor_target_chunk_size"),
+            target_eligibility=self._neighbor_target_eligibility(dataset),
         )
 
         gen_model = instantiate(

--- a/cel/pipelines/runners/dicoflex_runner.py
+++ b/cel/pipelines/runners/dicoflex_runner.py
@@ -197,7 +197,12 @@ class DiCoFlexPipelineRunner(PipelineRunner):
     def __init__(
         self, cfg: DictConfig, logger: logging.Logger, preprocessing_pipeline=None
     ) -> None:
-        """Initialise the runner and resolve the training device.
+        """Initialise the runner and resolve the flow-training device.
+
+        The GPU, when requested via ``experiment.use_gpu``, accelerates flow
+        training only. The trained flow is moved back to CPU before anything
+        else touches it, so generation, the classifier, and metrics all run on
+        CPU and checkpoints are CPU-loadable by default.
 
         Args:
             cfg: Hydra configuration for the pipeline run.
@@ -206,7 +211,9 @@ class DiCoFlexPipelineRunner(PipelineRunner):
         """
         super().__init__(cfg, logger, preprocessing_pipeline)
         use_gpu = cfg.experiment.get("use_gpu", False)
-        self.device = torch.device("cuda" if use_gpu and torch.cuda.is_available() else "cpu")
+        self._train_device = torch.device(
+            "cuda" if use_gpu and torch.cuda.is_available() else "cpu"
+        )
         self._flow: torch.nn.Module | None = None
         self._train_loader: torch.utils.data.DataLoader | None = None
         self._class_to_index: dict[int, int] = {}
@@ -256,12 +263,18 @@ class DiCoFlexPipelineRunner(PipelineRunner):
             self.cfg.gen_model.model,
             features=dataset.X_train.shape[1],
             context_features=context_dim,
-        ).to(self.device)
+        )
 
         if self.cfg.gen_model.train_model:
+            gen_model.to(self._train_device)
             train_dicoflex_generator(
-                gen_model, self._train_loader, val_loader, self.cfg, path, self.device
+                gen_model, self._train_loader, val_loader, self.cfg, path, self._train_device
             )
+            # Inference is CPU-only: bring the flow back and rewrite the best
+            # checkpoint with CPU tensors so it loads anywhere without
+            # map_location gymnastics.
+            gen_model.to(torch.device("cpu"))
+            gen_model.save(path)
         else:
             gen_model.load(path)
         self._flow = gen_model
@@ -286,7 +299,7 @@ class DiCoFlexPipelineRunner(PipelineRunner):
         cf_params = self.cfg.counterfactuals_params
         loader = full_training_loader(self._train_loader, cf_params.train_batch_factuals)
         threshold = flow_log_prob_threshold(
-            gen_model, loader, cf_params.log_prob_quantile, self.device
+            gen_model, loader, cf_params.log_prob_quantile, next(gen_model.parameters()).device
         )
         self.logger.info(f"log_prob_threshold: {threshold:.4f}")
         return threshold
@@ -357,7 +370,7 @@ class DiCoFlexPipelineRunner(PipelineRunner):
             class_to_index=self._class_to_index,
             mask_vectors=self._mask_vectors,
             params=params,
-            device=str(self.device),
+            device="cpu",
             monotonic_direction=monotonic_direction,
         )
 


### PR DESCRIPTION
Replaces the stacked PRs #68, #69 and #70 with a single port onto the refactored `develop` architecture. Those three were opened against pre-rename `main` (the package was `counterfactuals/`, now `cel/`) and a plain merge produced 127 conflicts, so this branch ports the working code file by file instead.

## Where the code comes from

`claude/dicoflex-neighbor-filter` (tip `8a13546`) is the source of truth. It is the branch that produced the experiment results: hashing every `.py`/`.yaml`/`.sbatch`/`.sh` file against the WCSS deployment at `/lustre/.../ce-dicoflex` gives 352 of 355 identical, and the three that differ are the scorer (one commit behind, runs elsewhere), an untracked timing script, and an unused flow-architecture config. `dictum-aligned-eval` is a strict ancestor of that branch and adds nothing on top.

## What is here so far

- `cel/cf_methods/local_methods/dicoflex/` — the method package, with proximity-based candidate selection and dead-candidate handling.
- Sampling temperature on `MaskedAutoregressiveFlow`. Sampling the base Gaussian at full variance is what made every architecture produce unbounded numeric tails; the table from the investigation, on bank/seed 42:

  | stage | proximity | LOF | validity |
  |---|---|---|---|
  | no temperature | 3.4e32 | inf | 1.00 |
  | + temperature 0.8 | 338 | finite | 0.95 |
  | + proximity selection | 28.6 | 0.327 | 1.00 |
  | + numeric clamp to box | 1.08 | 0.248 | 1.00 |

- `map_location` on `PytorchBase.load`, so a GPU-trained checkpoint opens on CPU.
- `MethodDataset.monotonic_features`.

## Still to come on this branch

- `DiCoFlexPipelineRunner` on the cross-validation runner architecture, plus the hydra wrapper and config. The numeric clamp to the `[0, 1]` box lands in `postprocess_cf_output`; it currently lives in a train/test pipeline script that this branch does not ship.
- A regression test asserting the actual failure signature (finite counterfactuals, bounded magnitude), not just validity — the broken version scored validity 1.00 while emitting `inf`.

## Not in scope

The DICTUM evaluation setup — pre-split datasets, the dual model space and classifier space adapter, the shared classifier, the scorer and the slurm jobs — is a separate branch off `develop` and is not proposed for merge. It diverges too far from the library's experimental conventions.

## Verification so far

Test suite is unchanged by these commits: 26 failed / 95 passed both with the changes and on stashed clean `develop`. Both failure sets are pre-existing. Note that `tests/test_pipelines/` does not collect on `develop` at all — `ImportError: cannot import name 'WACHOURSPipelineRunner' from 'cel.pipelines.runners'` — which will need addressing before the runner test can live there.

Draft until the runner lands.
